### PR TITLE
Add global pedestrian hazard analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,4 +186,5 @@ tests/*
 !tests/webmap_snapshot/
 !tests/webmap_snapshot/*.py
 !tests/test_routing_*.py
+!tests/test_hazard_analysis.py
 tests.py

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Python dictionaries and precomputed during node generation. See
 [`routing/README.md`](routing/README.md) for the architecture, slope-source
 hierarchy and calibration workflow.
 
+## Pedestrian hazard analysis
+
+The Hazard Analysis webmap evaluates the same normalized pedestrian network
+for general pedestrians, wheelchair users, blind/low-vision pedestrians, and
+older/reduced-mobility pedestrians. It publishes directional, evidence-backed
+severity rather than collapsing missing information into a safety claim.
+Global terrain context comes from the Copernicus GLO-30 and GLO-90 Cloud
+Optimized GeoTIFFs in the AWS Open Data Registry. See
+[`hazard_analysis/README.md`](hazard_analysis/README.md).
+
 ## Architecture
 
 ```text
@@ -38,6 +48,7 @@ OpenSidewalkMap project
 │   ├── data_quality/                validation and completeness analysis
 │   ├── datahub/                     static API, acquisition, and watcher/RSS
 │   ├── generation/                  PMTiles, VRT, and routing-data generators
+│   ├── hazard_analysis/             hazard policy, terrain overlays, and webmap
 │   ├── routing/                     static routing demonstration
 │   ├── runners/                     setup, daily, weekly, and custom pipelines
 │   ├── webmap/                      MapLibre Webmap and scrutiny snapshots
@@ -64,6 +75,7 @@ Generators run from the node root. They import shared code through the `oswm_cod
 | Data quality | Tag-value checks, geometry checks, report tables, QA maps, and external-provider links | Active |
 | Completeness | Multi-scale and temporal footway/sidewalk-to-road completeness analysis | Active; computationally and API intensive |
 | Routing demo | Client-side route exploration over generated pedestrian geometries | Experimental |
+| Hazard Analysis | Profile-specific pedestrian hazard screening and global terrain context | Experimental |
 | Data hub and static API | Human-readable hub plus serverless JSON, GeoParquet, PMTiles, VRT, and chart-spec endpoints | Active |
 | Change watcher and RSS | Detects relevant OSM changes, helps skip unnecessary pipeline runs, and emits HTML/RSS/Atom-style outputs | Active |
 | Acquisition | Discovers relevant mapping projects from supported third-party platforms | Active, dependent on external services |

--- a/accessibility/__init__.py
+++ b/accessibility/__init__.py
@@ -1,0 +1,21 @@
+"""Shared accessibility evidence normalization for OSWM modules."""
+
+from .normalization import (
+    is_unknown,
+    normalize_categorical,
+    normalize_sequence,
+    parse_incline_percent,
+    parse_number,
+    parse_width_m,
+    prepare_feature,
+)
+
+__all__ = [
+    "is_unknown",
+    "normalize_categorical",
+    "normalize_sequence",
+    "parse_incline_percent",
+    "parse_number",
+    "parse_width_m",
+    "prepare_feature",
+]

--- a/accessibility/normalization.py
+++ b/accessibility/normalization.py
@@ -1,0 +1,213 @@
+"""Normalize OSM accessibility evidence once for routing and hazard analysis."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+UNKNOWN_STRINGS = {"", "?", "unknown", "unset", "none", "null", "nan"}
+_NUMBER_RE = re.compile(r"[-+]?(?:\d+(?:[.,]\d*)?|[.,]\d+)")
+
+
+def is_unknown(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in UNKNOWN_STRINGS
+    try:
+        return bool(math.isnan(value))
+    except (TypeError, ValueError):
+        value_type = type(value)
+        return (
+            value_type.__name__ in {"NAType", "NaTType"}
+            and value_type.__module__.startswith("pandas")
+        )
+
+
+def normalize_categorical(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.strip().lower()
+    return value
+
+
+def normalize_sequence(value: Any) -> list[Any]:
+    if is_unknown(value):
+        return []
+    if isinstance(value, str):
+        return [normalize_categorical(value)]
+    if isinstance(value, Sequence):
+        return [
+            normalize_categorical(item)
+            for item in value
+            if not is_unknown(item)
+        ]
+    return [normalize_categorical(value)]
+
+
+def parse_number(value: Any) -> float | None:
+    """Parse the first finite number from a permissive OSM-style value."""
+
+    if is_unknown(value) or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        return number if math.isfinite(number) else None
+    match = _NUMBER_RE.search(str(value))
+    if not match:
+        return None
+    try:
+        number = float(match.group(0).replace(",", "."))
+    except ValueError:
+        return None
+    return number if math.isfinite(number) else None
+
+
+def parse_width_m(value: Any) -> float | None:
+    """Parse common OSM width forms into metres."""
+
+    if is_unknown(value):
+        return None
+    text = str(value).strip().lower()
+    if ";" in text:
+        parsed = [parse_width_m(part) for part in text.split(";")]
+        valid = [item for item in parsed if item is not None]
+        return min(valid) if valid else None
+
+    feet_match = re.fullmatch(
+        r"\s*(\d+(?:\.\d+)?)\s*'\s*(?:(\d+(?:\.\d+)?)\s*(?:\"|in)?)?\s*",
+        text,
+    )
+    if feet_match:
+        feet = float(feet_match.group(1))
+        inches = float(feet_match.group(2) or 0)
+        return feet * 0.3048 + inches * 0.0254
+
+    number = parse_number(value)
+    if number is None:
+        return None
+    if "ft" in text or "feet" in text:
+        return number * 0.3048
+    if "cm" in text:
+        return number / 100
+    if "mm" in text:
+        return number / 1000
+    return number
+
+
+def parse_incline_percent(value: Any) -> tuple[float | None, str]:
+    """Return ``(percent, kind)`` for an OSM incline-like value."""
+
+    if is_unknown(value):
+        return None, "missing"
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"up", "uphill", "down", "downhill"}:
+            return None, "qualitative"
+    else:
+        text = str(value)
+
+    number = parse_number(value)
+    if number is None:
+        return None, "invalid"
+    if "°" in text or "deg" in text or "degree" in text:
+        return math.tan(math.radians(number)) * 100, "numeric"
+    return number, "numeric"
+
+
+def _normalize_transition_states(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    normalized = []
+    for state in value:
+        if not isinstance(state, Mapping):
+            continue
+        normalized.append(
+            {
+                key: normalize_categorical(item)
+                for key, item in state.items()
+                if not is_unknown(item)
+            }
+        )
+    return normalized
+
+
+def prepare_feature(
+    feature: Mapping[str, Any],
+    *,
+    edge_kind: str | None = None,
+    estimated_slope_percent: float | None = None,
+    slope_source: str = "missing",
+    slope_confidence: int = 0,
+) -> dict[str, Any]:
+    """Normalize raw edge evidence for every accessibility consumer."""
+
+    prepared = dict(feature)
+    prepared["edge_kind"] = edge_kind or prepared.get("edge_kind") or "footway"
+    prepared["width_m"] = parse_width_m(prepared.get("width"))
+
+    direct_slope, incline_kind = parse_incline_percent(prepared.get("incline"))
+    if direct_slope is not None:
+        prepared["incline_percent"] = direct_slope
+        prepared["incline_source"] = "direct_osm_numeric"
+        prepared["incline_confidence"] = 100
+    else:
+        prepared["incline_percent"] = estimated_slope_percent
+        prepared["incline_source"] = (
+            slope_source if estimated_slope_percent is not None else incline_kind
+        )
+        prepared["incline_confidence"] = (
+            int(slope_confidence) if estimated_slope_percent is not None else 0
+        )
+
+    cross_slope, cross_kind = parse_incline_percent(
+        prepared.get("incline:across")
+    )
+    prepared["cross_slope_percent"] = cross_slope
+    prepared["cross_slope_source"] = (
+        "direct_osm_numeric" if cross_slope is not None else cross_kind
+    )
+    prepared["cross_slope_confidence"] = 100 if cross_slope is not None else 0
+
+    for field in (
+        "surface",
+        "smoothness",
+        "wheelchair",
+        "crossing",
+        "tactile_paving",
+        "kerb",
+        "lit",
+        "highway",
+        "access",
+        "foot",
+    ):
+        prepared[field] = normalize_categorical(prepared.get(field))
+
+    for field in (
+        "associated_kerbs",
+        "associated_tactile_paving",
+        "associated_kerb_surfaces",
+        "associated_sidewalk_surfaces",
+    ):
+        prepared[field] = normalize_sequence(prepared.get(field))
+
+    transitions = _normalize_transition_states(
+        prepared.get("associated_transition_states")
+    )
+    prepared["associated_transition_states"] = transitions
+
+    crossing_surface = prepared.get("surface")
+    prepared["uniform_transition_surface"] = bool(
+        prepared["edge_kind"] == "crossing"
+        and not is_unknown(crossing_surface)
+        and any(
+            not is_unknown(state.get("kerb_surface"))
+            and not is_unknown(state.get("sidewalk_surface"))
+            and crossing_surface == state.get("kerb_surface")
+            == state.get("sidewalk_surface")
+            for state in transitions
+        )
+    )
+    return prepared

--- a/assets/homepage/oswm_hazard_img.svg
+++ b/assets/homepage/oswm_hazard_img.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 430" role="img" aria-labelledby="title desc">
+  <title id="title">OpenSidewalkMap Hazard Analysis</title>
+  <desc id="desc">A stylized pedestrian map with graded terrain, a wheelchair user, tactile paving, and hazard markers.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#d8f2f5"/>
+      <stop offset="1" stop-color="#f8fbf7"/>
+    </linearGradient>
+    <linearGradient id="risk" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#fee08b"/>
+      <stop offset=".55" stop-color="#fdae61"/>
+      <stop offset="1" stop-color="#a50026"/>
+    </linearGradient>
+  </defs>
+  <rect width="900" height="430" rx="22" fill="url(#sky)"/>
+  <path d="M0 310C120 250 235 295 340 225s226-73 330-19 165 38 230 4v220H0z" fill="#a9d6ad"/>
+  <path d="M-35 378L183 207l175 72 190-144 387 231v99H-35z" fill="#d7d2c8"/>
+  <path d="M18 388L187 255l168 70 196-145 329 197" fill="none" stroke="#fff" stroke-width="64" stroke-linejoin="round"/>
+  <path d="M18 388L187 255l168 70 196-145 329 197" fill="none" stroke="url(#risk)" stroke-width="18" stroke-linejoin="round"/>
+  <g transform="translate(327 270)">
+    <circle cx="0" cy="0" r="28" fill="#165a72"/>
+    <circle cx="0" cy="0" r="17" fill="#fff"/>
+    <circle cx="13" cy="-43" r="12" fill="#165a72"/>
+    <path d="M10-28L-3-4l28 12 15 29M5-18l31 1" fill="none" stroke="#165a72" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <g transform="translate(548 132)">
+    <path d="M0 104L58 0l58 104z" fill="#fff" stroke="#a50026" stroke-width="12" stroke-linejoin="round"/>
+    <path d="M58 32v37" stroke="#a50026" stroke-width="11" stroke-linecap="round"/>
+    <circle cx="58" cy="86" r="6" fill="#a50026"/>
+  </g>
+  <g fill="#f0c419" stroke="#7d6510" stroke-width="2">
+    <circle cx="500" cy="208" r="7"/><circle cx="521" cy="208" r="7"/><circle cx="542" cy="208" r="7"/>
+    <circle cx="500" cy="229" r="7"/><circle cx="521" cy="229" r="7"/><circle cx="542" cy="229" r="7"/>
+  </g>
+  <text x="42" y="62" fill="#123c4a" font-family="Arial, sans-serif" font-size="34" font-weight="700">HAZARD ANALYSIS</text>
+  <text x="44" y="93" fill="#376471" font-family="Arial, sans-serif" font-size="18">Different pedestrians · different risks</text>
+</svg>

--- a/constants.py
+++ b/constants.py
@@ -32,6 +32,7 @@ data_quality_folderpath = os.path.join(data_folderpath, "data_quality")
 boundaries_folderpath = os.path.join(data_folderpath, "boundaries")
 updates_folderpath = os.path.join(data_folderpath, "updates")
 routing_folderpath = os.path.join(data_folderpath, "routing")
+hazard_analysis_folderpath = os.path.join(data_folderpath, "hazard_analysis")
 snapshots_folderpath = os.path.join(data_folderpath, "snapshots")
 
 improper_geoms_folderpath = os.path.join(data_quality_folderpath, "improper_geoms")
@@ -51,6 +52,23 @@ routing_demo_path = os.path.join(routing_folderpath, "demo.geojson")
 routing_profiles_path = os.path.join(routing_folderpath, "profiles.json")
 routing_metadata_path = os.path.join(routing_folderpath, "metadata.json")
 routing_slope_cache_path = os.path.join(routing_folderpath, "slope_cache.json")
+hazard_profiles_path = os.path.join(
+    hazard_analysis_folderpath, "profiles.json"
+)
+hazard_metadata_path = os.path.join(
+    hazard_analysis_folderpath, "metadata.json"
+)
+hazard_terrain_metadata_path = os.path.join(
+    hazard_analysis_folderpath, "terrain.json"
+)
+
+
+def hazard_profile_features_path(profile_id):
+    return os.path.join(
+        hazard_analysis_folderpath, f"features_{profile_id}.geojson"
+    )
+
+
 pipeline_failures_path = os.path.join(updates_folderpath, "pipeline_failures.txt")
 snapshot_summary_path = os.path.join(snapshots_folderpath, "node_summary.json")
 

--- a/datahub/API/generate_api.py
+++ b/datahub/API/generate_api.py
@@ -45,6 +45,8 @@ def get_endpoint_category(path, deliverable):
             return "GDAL VRT Descriptors"
         elif "routing" in path:
             return "Routing & Demos"
+        elif "hazard_analysis" in path:
+            return "Pedestrian Hazard Analysis"
         elif path == "webmap_params.json":
             return "Boundaries & Config"
         return "Map Data Assets"
@@ -127,7 +129,18 @@ def get_endpoint_description(path, filename, deliverable):
             "data/routing/demo.geojson": "Transitional GeoJSON routing network with compact, directional accessibility grades.",
             "data/routing/profiles.json": "Browser-safe distance/accessibility routing modes, labels, speeds, grade-to-cost multipliers, and event penalties.",
             "data/routing/metadata.json": "Routing ruleset provenance, slope-source counts, warnings, and generated grade distributions.",
-            "data/routing/slope_cache.json": "Reusable derived longitudinal slope estimates keyed by edge geometry and provider configuration."
+            "data/routing/slope_cache.json": "Reusable derived longitudinal slope estimates keyed by edge geometry and provider configuration.",
+            "data/hazard_analysis/profiles.json": "Browser-safe hazard profiles, severity levels, categories, explanations, effects, and ruleset provenance.",
+            "data/hazard_analysis/metadata.json": "Hazard generation audit, evidence caveats, severity counts, and elevation-source provenance.",
+            "data/hazard_analysis/terrain.json": "Terrain overlay bounds, profile thresholds, global AWS DEM attribution, and availability status.",
+            "data/hazard_analysis/features_pedestrian.geojson": "Pedestrian-profile hazard screening with directional evidence and category severities.",
+            "data/hazard_analysis/features_wheelchair.geojson": "Wheelchair-profile hazard screening with directional evidence and category severities.",
+            "data/hazard_analysis/features_blind.geojson": "Blind/low-vision-profile hazard screening with directional evidence and category severities.",
+            "data/hazard_analysis/features_elderly.geojson": "Older/reduced-mobility-profile hazard screening with directional evidence and category severities.",
+            "data/hazard_analysis/terrain_pedestrian.png": "Transparent pedestrian terrain-difficulty overlay derived from the configured global AWS DEM.",
+            "data/hazard_analysis/terrain_wheelchair.png": "Transparent wheelchair terrain-difficulty overlay derived from the configured global AWS DEM.",
+            "data/hazard_analysis/terrain_blind.png": "Transparent blind/low-vision terrain-difficulty overlay derived from the configured global AWS DEM.",
+            "data/hazard_analysis/terrain_elderly.png": "Transparent older/reduced-mobility terrain-difficulty overlay derived from the configured global AWS DEM."
         }
         if path in curated_descs:
             return curated_descs[path]
@@ -238,6 +251,10 @@ def generate_data_index():
         "routing": {
             "description": "Routing files, network properties, and routing demo data.",
             "path": "data/routing"
+        },
+        "hazard_analysis": {
+            "description": "Profile-specific pedestrian hazard evidence and global terrain-difficulty overlays.",
+            "path": "data/hazard_analysis"
         }
     }
     
@@ -271,6 +288,20 @@ def generate_data_index():
                     "profiles.json",
                     "metadata.json",
                     "slope_cache.json",
+                ]
+            elif key == "hazard_analysis":
+                files = [
+                    "profiles.json",
+                    "metadata.json",
+                    "terrain.json",
+                    "features_pedestrian.geojson",
+                    "features_wheelchair.geojson",
+                    "features_blind.geojson",
+                    "features_elderly.geojson",
+                    "terrain_pedestrian.png",
+                    "terrain_wheelchair.png",
+                    "terrain_blind.png",
+                    "terrain_elderly.png",
                 ]
         
         data_idx["folders"][key] = {
@@ -316,6 +347,8 @@ def collect_endpoints():
                 fmt = "PMTiles"
             elif ext == ".vrt":
                 fmt = "XML/VRT"
+            elif ext == ".png":
+                fmt = "PNG"
             elif ext == ".html":
                 continue # Skip HTML files like updating status page
                 

--- a/generation/routing_demo_gen.py
+++ b/generation/routing_demo_gen.py
@@ -1,4 +1,4 @@
-"""Generate the static, accessibility-aware OSWM routing dataset.
+"""Generate shared accessibility-aware routing and hazard datasets.
 
 The current output remains GeoJSON so existing nodes can adopt profiles before
 the planned compact binary graph format lands. All expensive policy decisions
@@ -18,6 +18,7 @@ from typing import Any
 
 import geopandas as gpd
 import pandas as pd
+from shapely.geometry import mapping
 
 # The generator runs from a node repository while this file lives inside the
 # oswm_codebase submodule.
@@ -29,6 +30,28 @@ if oswm_dir not in sys.path:
     sys.path.insert(0, oswm_dir)
 
 import constants
+from accessibility.normalization import (
+    is_unknown,
+    parse_incline_percent,
+    prepare_feature,
+)
+from hazard_analysis.assessment import (
+    assess_feature,
+    compact_hazard_properties,
+)
+from hazard_analysis.rules import (
+    HAZARD_CATEGORIES,
+    HAZARD_PROFILES,
+    HAZARD_RULES,
+    HAZARD_RULESET_VERSION,
+    SEVERITY_LEVELS,
+)
+from hazard_analysis.terrain import generate_terrain_overlays
+from hazard_analysis.validation import (
+    public_rule_metadata,
+    ruleset_hash as hazard_ruleset_hash,
+    validate_rules,
+)
 from routing.elevation import (
     ElevationResolver,
     SlopeEstimate,
@@ -39,8 +62,6 @@ from routing.elevation import (
 from routing.grading import (
     compact_grade_properties,
     grade_feature,
-    is_unknown,
-    parse_incline_percent,
 )
 from routing.profile_rules import (
     DEFAULT_ELEVATION_CONFIG,
@@ -84,12 +105,13 @@ def _prepare_lines(gdf: gpd.GeoDataFrame, source_layer: str) -> gpd.GeoDataFrame
     return valid
 
 
-def _associate_kerbs(
+def _associate_crossing_context(
     crossings: gpd.GeoDataFrame,
     kerbs: gpd.GeoDataFrame | None,
+    sidewalks: gpd.GeoDataFrame | None,
     radius_m: float = 2.0,
 ) -> gpd.GeoDataFrame:
-    """Attach nearby kerb/tactile values without committing source attributes."""
+    """Attach paired kerb/tactile and nearby surface evidence."""
 
     crossings = crossings.copy()
     crossing_kerbs = (
@@ -108,6 +130,25 @@ def _associate_kerbs(
     crossings["associated_tactile_paving"] = [
         [] if is_unknown(value) else [value] for value in crossing_tactile
     ]
+    crossings["associated_kerb_surfaces"] = [[] for _ in range(len(crossings))]
+    crossings["associated_sidewalk_surfaces"] = [
+        [] for _ in range(len(crossings))
+    ]
+    crossings["associated_transition_states"] = [
+        [
+            {
+                **({} if is_unknown(kerb) else {"kerb": kerb}),
+                **(
+                    {}
+                    if is_unknown(tactile)
+                    else {"tactile_paving": tactile}
+                ),
+            }
+        ]
+        if not is_unknown(kerb) or not is_unknown(tactile)
+        else []
+        for kerb, tactile in zip(crossing_kerbs, crossing_tactile)
+    ]
     if crossings.empty or kerbs is None or kerbs.empty:
         return crossings
 
@@ -125,43 +166,125 @@ def _associate_kerbs(
     crossing_metric = crossings.to_crs(metric_crs).reset_index(drop=True)
     kerb_metric = kerbs.to_crs(metric_crs).reset_index(drop=True)
     spatial_index = kerb_metric.sindex
+    sidewalk_metric = None
+    sidewalk_index = None
+    if sidewalks is not None and not sidewalks.empty:
+        sidewalk_metric = sidewalks.to_crs(metric_crs).reset_index(drop=True)
+        sidewalk_index = sidewalk_metric.sindex
 
     kerb_lists: list[list[Any]] = []
     tactile_lists: list[list[Any]] = []
+    kerb_surface_lists: list[list[Any]] = []
+    sidewalk_surface_lists: list[list[Any]] = []
+    transition_lists: list[list[dict[str, Any]]] = []
     for position, geometry in enumerate(crossing_metric.geometry):
         candidate_positions = list(
             spatial_index.query(geometry.buffer(radius_m), predicate="intersects")
         )
         nearby = kerb_metric.iloc[candidate_positions]
-        kerb_lists.append(
-            crossings.iloc[position]["associated_kerbs"]
-            + [
-                value
-                for value in nearby.get("kerb", pd.Series(dtype=object)).tolist()
-                if not is_unknown(value)
-            ]
-        )
-        tactile_lists.append(
+        kerb_values = list(crossings.iloc[position]["associated_kerbs"])
+        tactile_values = list(
             crossings.iloc[position]["associated_tactile_paving"]
-            + [
-                value
-                for value in nearby.get(
-                    "tactile_paving", pd.Series(dtype=object)
-                ).tolist()
-                if not is_unknown(value)
-            ]
         )
+        kerb_surfaces = []
+        sidewalk_surfaces = []
+        transitions = list(
+            crossings.iloc[position]["associated_transition_states"]
+        )
+        for _nearby_position, kerb_row in nearby.iterrows():
+            kerb_value = kerb_row.get("kerb")
+            tactile_value = kerb_row.get("tactile_paving")
+            kerb_surface = kerb_row.get("surface")
+            if not is_unknown(kerb_value):
+                kerb_values.append(kerb_value)
+            if not is_unknown(tactile_value):
+                tactile_values.append(tactile_value)
+            if not is_unknown(kerb_surface):
+                kerb_surfaces.append(kerb_surface)
+
+            sidewalk_surface = None
+            if sidewalk_metric is not None and sidewalk_index is not None:
+                sidewalk_candidates = list(
+                    sidewalk_index.query(
+                        kerb_row.geometry.buffer(radius_m),
+                        predicate="intersects",
+                    )
+                )
+                if sidewalk_candidates:
+                    nearby_sidewalks = sidewalk_metric.iloc[
+                        sidewalk_candidates
+                    ].copy()
+                    nearby_sidewalks["_distance"] = (
+                        nearby_sidewalks.geometry.distance(kerb_row.geometry)
+                    )
+                    closest = nearby_sidewalks.sort_values("_distance").iloc[0]
+                    sidewalk_surface = closest.get("surface")
+                    if not is_unknown(sidewalk_surface):
+                        sidewalk_surfaces.append(sidewalk_surface)
+
+            state = {}
+            for key, value in (
+                ("kerb", kerb_value),
+                ("tactile_paving", tactile_value),
+                ("kerb_surface", kerb_surface),
+                ("sidewalk_surface", sidewalk_surface),
+            ):
+                if not is_unknown(value):
+                    state[key] = value
+            if state:
+                transitions.append(state)
+
+        kerb_lists.append(kerb_values)
+        tactile_lists.append(tactile_values)
+        kerb_surface_lists.append(kerb_surfaces)
+        sidewalk_surface_lists.append(sidewalk_surfaces)
+        transition_lists.append(transitions)
 
     crossings["associated_kerbs"] = kerb_lists
     crossings["associated_tactile_paving"] = tactile_lists
+    crossings["associated_kerb_surfaces"] = kerb_surface_lists
+    crossings["associated_sidewalk_surfaces"] = sidewalk_surface_lists
+    crossings["associated_transition_states"] = transition_lists
     return crossings
 
 
-def _json_dump(payload: dict[str, Any], path: str) -> None:
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as handle:
-        json.dump(payload, handle, indent=2, ensure_ascii=False, sort_keys=True)
-        handle.write("\n")
+def _json_dump(
+    payload: dict[str, Any],
+    path: str,
+    *,
+    expected_feature_count: int | None = None,
+) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.parent / (
+        f".{destination.name}.tmp.{os.getpid()}"
+    )
+    try:
+        with temporary.open("w", encoding="utf-8") as handle:
+            json.dump(
+                payload,
+                handle,
+                indent=None if expected_feature_count is not None else 2,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":")
+                if expected_feature_count is not None
+                else None,
+            )
+            handle.write("\n")
+        with temporary.open(encoding="utf-8") as handle:
+            check = json.load(handle)
+        if expected_feature_count is not None:
+            actual = len(check.get("features", []))
+            if actual != expected_feature_count:
+                raise ValueError(
+                    f"{destination}: expected {expected_feature_count} "
+                    f"features, got {actual}"
+                )
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
 
 
 def _profile_audit(
@@ -198,9 +321,33 @@ def _profile_audit(
     return audit
 
 
+def _hazard_audit(
+    profile_properties: dict[str, list[dict[str, Any]]],
+) -> dict[str, dict[str, Any]]:
+    audit = {}
+    for profile_id, properties in profile_properties.items():
+        severities = [int(item["severity"]) for item in properties]
+        statuses = Counter(item["status"] for item in properties)
+        rules = Counter(
+            rule_id
+            for item in properties
+            for rule_id in item.get("rule_ids", [])
+        )
+        audit[profile_id] = {
+            "severity_counts": {
+                str(level): severities.count(level)
+                for level in SEVERITY_LEVELS
+            },
+            "status_counts": dict(statuses),
+            "most_common_decisive_rules": dict(rules.most_common(10)),
+        }
+    return audit
+
+
 def main() -> None:
     print("Generating accessibility-aware routing data...")
     validate_profiles(ROUTING_PROFILES)
+    validate_rules(HAZARD_RULES)
 
     required = [
         (constants.sidewalks_path, "sidewalks"),
@@ -226,7 +373,7 @@ def main() -> None:
         if os.path.exists(constants.kerbs_path)
         else None
     )
-    crossings = _associate_kerbs(crossings, kerbs)
+    crossings = _associate_crossing_context(crossings, kerbs, sidewalks)
 
     nonempty = [
         frame for frame in (sidewalks, crossings, other_footways) if not frame.empty
@@ -258,6 +405,12 @@ def main() -> None:
 
     output_rows: list[dict[str, Any]] = []
     output_properties: list[dict[str, Any]] = []
+    hazard_features: dict[str, list[dict[str, Any]]] = {
+        profile_id: [] for profile_id in HAZARD_PROFILES
+    }
+    hazard_properties: dict[str, list[dict[str, Any]]] = {
+        profile_id: [] for profile_id in HAZARD_PROFILES
+    }
     source_counts: Counter[str] = Counter()
     for position, (_index, row) in enumerate(combined.iterrows()):
         raw_incline = row.get("incline")
@@ -286,13 +439,21 @@ def main() -> None:
             new_slope_cache[cache_key] = slope.to_dict()
         source_counts[slope.source] += 1
 
-        graded = grade_feature(
+        prepared = prepare_feature(
             row.to_dict(),
             edge_kind=row["edge_kind"],
             estimated_slope_percent=slope.percent,
             slope_source=slope.source,
             slope_confidence=slope.confidence,
         )
+        graded = grade_feature(
+            prepared,
+            edge_kind=row["edge_kind"],
+            estimated_slope_percent=slope.percent,
+            slope_source=slope.source,
+            slope_confidence=slope.confidence,
+        )
+        assessed = assess_feature(prepared, normalized=True)
         properties: dict[str, Any] = {
             "routing_id": f"{row['source_layer']}:{row.get('id', position)}:{position}",
             "source_id": str(row.get("id", position)),
@@ -311,12 +472,50 @@ def main() -> None:
         properties.update(compact_grade_properties(graded))
         output_properties.append(properties)
         output_rows.append({**properties, "geometry": row.geometry})
+        for profile_id in HAZARD_PROFILES:
+            hazard = {
+                "routing_id": properties["routing_id"],
+                "source_id": properties["source_id"],
+                "edge_kind": properties["edge_kind"],
+                "length_m": properties["length_m"],
+                "slope_pct": properties["slope_pct"],
+                "slope_source": properties["slope_source"],
+                "slope_confidence": properties["slope_confidence"],
+                **compact_hazard_properties(assessed, profile_id),
+            }
+            hazard_properties[profile_id].append(hazard)
+            hazard_features[profile_id].append(
+                {
+                    "type": "Feature",
+                    "geometry": mapping(row.geometry),
+                    "properties": hazard,
+                }
+            )
+    resolver.close()
 
     os.makedirs(constants.routing_folderpath, exist_ok=True)
     save_slope_cache(constants.routing_slope_cache_path, new_slope_cache)
 
-    output = gpd.GeoDataFrame(output_rows, geometry="geometry", crs="EPSG:4326")
-    output.to_file(constants.routing_demo_path, driver="GeoJSON")
+    routing_collection = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": mapping(row["geometry"]),
+                "properties": {
+                    key: value
+                    for key, value in row.items()
+                    if key != "geometry"
+                },
+            }
+            for row in output_rows
+        ],
+    }
+    _json_dump(
+        routing_collection,
+        constants.routing_demo_path,
+        expected_feature_count=len(output_rows),
+    )
 
     rules_hash = profile_ruleset_hash(ROUTING_PROFILES)
     distance_profile_id = next(
@@ -338,23 +537,97 @@ def main() -> None:
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "ruleset_version": PROFILE_RULESET_VERSION,
         "ruleset_hash": rules_hash,
-        "feature_count": len(output),
-        "edge_kind_counts": dict(Counter(output["edge_kind"])),
+        "feature_count": len(output_rows),
+        "edge_kind_counts": dict(
+            Counter(item["edge_kind"] for item in output_properties)
+        ),
         "slope_source_counts": dict(source_counts),
         "elevation_provider_fingerprint": resolver_fingerprint,
         "profile_audit": _profile_audit(output_properties),
         "warnings": [
             "Profile rules are provisional and require participatory calibration.",
             (
-                "Copernicus GLO-30 is a 30 m surface model; its slopes describe "
-                "terrain trend, not measured sidewalk or cross slope."
+                "Global DEM providers describe terrain trend, not measured "
+                "sidewalk or cross slope."
             ),
         ],
     }
     _json_dump(metadata, constants.routing_metadata_path)
+
+    os.makedirs(constants.hazard_analysis_folderpath, exist_ok=True)
+    for profile_id, features in hazard_features.items():
+        _json_dump(
+            {"type": "FeatureCollection", "features": features},
+            constants.hazard_profile_features_path(profile_id),
+            expected_feature_count=len(output_rows),
+        )
+
+    hazard_hash = hazard_ruleset_hash(HAZARD_RULES)
+    hazard_profile_payload = {
+        "schema_version": 1,
+        "ruleset_version": HAZARD_RULESET_VERSION,
+        "ruleset_hash": hazard_hash,
+        "profiles": HAZARD_PROFILES,
+        "categories": HAZARD_CATEGORIES,
+        "severity_levels": {
+            str(level): metadata
+            for level, metadata in SEVERITY_LEVELS.items()
+        },
+        "rules": public_rule_metadata(HAZARD_RULES),
+    }
+    _json_dump(hazard_profile_payload, constants.hazard_profiles_path)
+
+    terrain_config = getattr(
+        constants,
+        "HAZARD_TERRAIN_CONFIG",
+        {
+            "enabled": True,
+            "max_dimension": 1600,
+            "smoothing_sigma_pixels": 3.0,
+        },
+    )
+    bounds = tuple(float(value) for value in combined.total_bounds)
+    terrain_metadata = generate_terrain_overlays(
+        bounds,
+        elevation_config,
+        terrain_config,
+        constants.hazard_analysis_folderpath,
+    )
+    terrain_metadata["generated_at"] = datetime.now(timezone.utc).isoformat()
+    _json_dump(terrain_metadata, constants.hazard_terrain_metadata_path)
+
+    hazard_metadata = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "ruleset_version": HAZARD_RULESET_VERSION,
+        "ruleset_hash": hazard_hash,
+        "feature_count": len(output_rows),
+        "edge_kind_counts": dict(
+            Counter(item["edge_kind"] for item in output_properties)
+        ),
+        "slope_source_counts": dict(source_counts),
+        "profile_audit": _hazard_audit(hazard_properties),
+        "warnings": [
+            "Hazard rules are provisional and require participatory calibration.",
+            (
+                "Missing evidence is never converted into a negative claim; "
+                "unflagged does not mean safe."
+            ),
+            (
+                "Surface material is used only as a low-confidence proxy where "
+                "direct smoothness evidence is unavailable."
+            ),
+            (
+                "Terrain rasters show unsigned contextual potential from a "
+                "global DSM, never measured sidewalk or cross slope."
+            ),
+        ],
+    }
+    _json_dump(hazard_metadata, constants.hazard_metadata_path)
     print(
-        f"Generated {len(output)} routable features at "
-        f"{constants.routing_demo_path}."
+        f"Generated {len(output_rows)} routable features at "
+        f"{constants.routing_demo_path} and {len(output_rows)} hazard "
+        "features per profile."
     )
 
 

--- a/hazard_analysis/README.md
+++ b/hazard_analysis/README.md
@@ -1,0 +1,108 @@
+# OSWM Hazard Analysis
+
+Hazard Analysis is a static, evidence-based webmap that identifies conditions
+which may be uncomfortable, unfavorable, dangerous, or critical for different
+pedestrians. It shares normalized evidence and longitudinal slope estimates
+with the routing module, but keeps hazard severity separate from routing grade.
+
+## Interpretation
+
+The module is a screening and prioritization tool, not an accessibility
+certificate. A severity of zero means **no rule matched the available
+evidence**; it does not mean that a feature is safe. Missing tags remain
+unknown and may produce `insufficient_data`.
+
+The five levels are:
+
+| Level | Label | Meaning |
+|---:|---|---|
+| 0 | No detected hazard | No rule matched known evidence |
+| 1 | Uncomfortable | Additional effort or reduced comfort |
+| 2 | Unfavorable | Meaningful accessibility degradation |
+| 3 | Dangerous | Serious safety or mobility concern |
+| 4 | Critical | Apparent barrier or extreme contextual risk |
+
+Critical results include a separate `traversability` field so an impassable
+barrier is not confused with a technically passable but extremely risky
+condition.
+
+## Profiles and categories
+
+The profiles are general pedestrian, wheelchair user, blind/low-vision
+pedestrian, and older/reduced-mobility pedestrian. Rules cover:
+
+- longitudinal slope, separately for each travel direction;
+- explicit `incline:across=*` cross slope;
+- kerb transitions;
+- tactile and material-transition detectability;
+- surface smoothness and provisional material proxies;
+- explicit barriers.
+
+Rules are plain dictionaries in [`rules.py`](rules.py). They are provisional
+and should be calibrated with affected users and accessibility specialists.
+Surface material has deliberately lower confidence than direct smoothness
+evidence. A missing tactile tag is never interpreted as `tactile_paving=no`.
+
+Kerb and tactile values are paired by the same nearby transition record.
+This prevents a flush kerb at one end of a crossing from being falsely paired
+with absent tactile paving recorded at the opposite end. The uniform-surface
+proxy is emitted only when crossing, kerb, and adjacent sidewalk surfaces are
+all explicitly mapped and equal.
+
+## Global terrain source
+
+The default source hierarchy is:
+
+1. numeric OSM `incline=*` for a network feature;
+2. Copernicus DEM GLO-30 Public (2021) Cloud Optimized GeoTIFFs from the AWS
+   Open Data Registry;
+3. Copernicus DEM GLO-90 (2021) from AWS when a public GLO-30 tile is absent;
+4. unknown.
+
+Both AWS buckets are public and require no AWS account. Tiles are cached in
+`.cache/oswm/elevation/`. GLO-30 is not quite complete because a small set of
+30 m tiles has not been publicly released; GLO-90 supplies worldwide land
+coverage for those cells.
+
+Copernicus DEM is a **digital surface model**, including vegetation and built
+structures. Its slope is low-confidence terrain context—not surveyed sidewalk
+grade. The optional raster is therefore titled *Terrain difficulty potential*.
+It is unsigned, smoothed for contextual display, and never used to infer cross
+slope. Numeric OSM incline remains authoritative.
+
+The generated metadata carries the required Copernicus attribution and source
+URL. Node configuration lives in `ELEVATION_CONFIG` and
+`HAZARD_TERRAIN_CONFIG` in the node's `config.py`.
+
+## Shared generation
+
+`generation/routing_demo_gen.py` produces routing and hazard artifacts in one
+pass. Each network feature is normalized once, receives one cached slope
+estimate, and is then evaluated by both policies. Outputs are written
+atomically and parsed again before replacing the previous files.
+
+Generated files:
+
+| File | Purpose |
+|---|---|
+| `data/hazard_analysis/profiles.json` | Public profiles, levels, categories, explanations, and rule effects |
+| `data/hazard_analysis/metadata.json` | Ruleset hash, generation audit, and warnings |
+| `data/hazard_analysis/features_<profile>.geojson` | One lazy-loaded feature collection per profile |
+| `data/hazard_analysis/terrain.json` | Raster bounds, source, licence, attribution, and thresholds |
+| `data/hazard_analysis/terrain_<profile>.png` | Optional transparent terrain-potential image |
+
+Profile GeoJSON and terrain PNG files are generated deployment artifacts and
+can remain Git-ignored. The daily Pages workflow generates them before
+publishing the node.
+
+## Calibration workflow
+
+1. Change only the policy dictionaries in `rules.py`.
+2. Increment `HAZARD_RULESET_VERSION`.
+3. Run the hazard and routing test suites.
+4. Generate a representative node and inspect the profile audit.
+5. Review samples with affected user groups.
+6. Record the calibration basis before propagating the codebase version.
+
+The deterministic ruleset hash makes every generated result traceable to the
+exact policy used.

--- a/hazard_analysis/__init__.py
+++ b/hazard_analysis/__init__.py
@@ -1,0 +1,12 @@
+"""Pedestrian hazard assessment for OpenSidewalkMap."""
+
+from .assessment import assess_feature, compact_hazard_properties
+from .rules import HAZARD_PROFILES, HAZARD_RULES, HAZARD_RULESET_VERSION
+
+__all__ = [
+    "HAZARD_PROFILES",
+    "HAZARD_RULES",
+    "HAZARD_RULESET_VERSION",
+    "assess_feature",
+    "compact_hazard_properties",
+]

--- a/hazard_analysis/assessment.py
+++ b/hazard_analysis/assessment.py
@@ -1,0 +1,272 @@
+"""Evaluate normalized pedestrian evidence against the hazard policy."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from accessibility.normalization import (
+    is_unknown,
+    normalize_categorical,
+    parse_number,
+    prepare_feature,
+)
+
+from .rules import HAZARD_CATEGORIES, HAZARD_PROFILES, HAZARD_RULES
+
+
+def _condition_matches(
+    condition: Mapping[str, Any], feature: Mapping[str, Any]
+) -> bool:
+    actual = feature.get(condition["field"])
+    operator = condition["operator"]
+
+    if operator == "transition_pair":
+        if not isinstance(actual, Sequence) or isinstance(actual, str):
+            return False
+        return any(
+            isinstance(state, Mapping)
+            and normalize_categorical(state.get("kerb"))
+            == normalize_categorical(condition.get("kerb"))
+            and normalize_categorical(state.get("tactile_paving"))
+            == normalize_categorical(condition.get("tactile_paving"))
+            for state in actual
+        )
+    if operator == "equals":
+        return normalize_categorical(actual) == normalize_categorical(
+            condition.get("value")
+        )
+    if operator == "contains":
+        if not isinstance(actual, Sequence) or isinstance(actual, str):
+            return False
+        expected = normalize_categorical(condition.get("value"))
+        return expected in {normalize_categorical(item) for item in actual}
+    if operator == "in":
+        expected = {
+            normalize_categorical(item) for item in condition.get("value", [])
+        }
+        return normalize_categorical(actual) in expected
+
+    number = parse_number(actual)
+    if number is None:
+        return False
+    if operator == "gt":
+        return number > float(condition["value"])
+    if operator == "gte":
+        return number >= float(condition["value"])
+    if operator == "lt":
+        return number < float(condition["value"])
+    if operator == "lte":
+        return number <= float(condition["value"])
+    if operator == "abs_gt":
+        return abs(number) > float(condition["value"])
+    if operator == "range":
+        return (
+            number > float(condition["min_exclusive"])
+            and number <= float(condition["max_inclusive"])
+        )
+    if operator == "abs_range":
+        magnitude = abs(number)
+        return (
+            magnitude > float(condition["min_exclusive"])
+            and magnitude <= float(condition["max_inclusive"])
+        )
+    if operator == "negative_range":
+        magnitude = abs(number)
+        return (
+            number < 0
+            and magnitude > float(condition["min_abs_exclusive"])
+            and magnitude <= float(condition["max_abs_inclusive"])
+        )
+    raise ValueError(f"unsupported hazard condition operator: {operator}")
+
+
+def _coverage(feature: Mapping[str, Any]) -> int:
+    evidence = [
+        not is_unknown(feature.get("surface")),
+        not is_unknown(feature.get("smoothness")),
+        parse_number(feature.get("incline_percent")) is not None,
+        parse_number(feature.get("cross_slope_percent")) is not None,
+        not is_unknown(feature.get("wheelchair")),
+    ]
+    if feature.get("edge_kind") == "crossing":
+        evidence.extend(
+            [
+                bool(feature.get("associated_kerbs")),
+                bool(feature.get("associated_tactile_paving")),
+                bool(feature.get("associated_transition_states")),
+            ]
+        )
+    return round(sum(evidence) / len(evidence) * 100)
+
+
+def _rule_confidence(
+    rule: Mapping[str, Any], feature: Mapping[str, Any]
+) -> int:
+    confidence = int(rule["confidence"])
+    if rule["category"] == "longitudinal_slope":
+        confidence = min(
+            confidence, int(feature.get("incline_confidence") or 0)
+        )
+    elif rule["category"] == "cross_slope":
+        confidence = min(
+            confidence, int(feature.get("cross_slope_confidence") or 0)
+        )
+    return confidence
+
+
+def _direction_assessment(
+    feature: Mapping[str, Any],
+    profile_id: str,
+    direction: str,
+    rules: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    directional = dict(feature)
+    incline = parse_number(feature.get("incline_percent"))
+    directional["directional_incline_percent"] = (
+        None
+        if incline is None
+        else incline if direction == "forward" else -incline
+    )
+    edge_kind = str(feature.get("edge_kind") or "footway")
+    matches = []
+    for rule in rules:
+        if profile_id not in rule["effects"]:
+            continue
+        contexts = rule.get("applies_to", [])
+        if contexts and edge_kind not in contexts:
+            continue
+        if _condition_matches(rule["condition"], directional):
+            effect = dict(rule["effects"][profile_id])
+            matches.append(
+                {
+                    "rule_id": rule["id"],
+                    "category": rule["category"],
+                    "description": rule["description"],
+                    "confidence": _rule_confidence(rule, directional),
+                    **effect,
+                }
+            )
+
+    categories: dict[str, dict[str, Any]] = {}
+    for category_id in HAZARD_CATEGORIES:
+        category_matches = [
+            match for match in matches if match["category"] == category_id
+        ]
+        severity = max(
+            (int(match["severity"]) for match in category_matches), default=0
+        )
+        categories[category_id] = {
+            "severity": severity,
+            "rule_ids": [
+                match["rule_id"]
+                for match in category_matches
+                if int(match["severity"]) == severity
+            ],
+        }
+
+    severity = max((int(match["severity"]) for match in matches), default=0)
+    decisive = [
+        match for match in matches if int(match["severity"]) == severity
+    ]
+    traversability_order = {
+        "passable": 0,
+        "passable_with_extreme_risk": 1,
+        "impassable": 2,
+    }
+    traversability = max(
+        (match["traversability"] for match in decisive),
+        default="passable",
+        key=lambda value: traversability_order[value],
+    )
+    coverage = _coverage(feature)
+    if severity:
+        status = "hazard_detected"
+    elif coverage >= 60:
+        status = "no_detected_hazard"
+    else:
+        status = "insufficient_data"
+    return {
+        "severity": severity,
+        "impact": sorted({match["impact"] for match in decisive}),
+        "traversability": traversability,
+        "confidence": max(
+            (int(match["confidence"]) for match in decisive),
+            default=coverage,
+        ),
+        "coverage": coverage,
+        "status": status,
+        "rule_ids": [match["rule_id"] for match in decisive],
+        "categories": categories,
+        "evidence": matches,
+    }
+
+
+def assess_feature(
+    feature: Mapping[str, Any],
+    *,
+    normalized: bool = False,
+    rules: Sequence[Mapping[str, Any]] = HAZARD_RULES,
+) -> dict[str, Any]:
+    prepared = dict(feature) if normalized else prepare_feature(feature)
+    return {
+        profile_id: {
+            direction: _direction_assessment(
+                prepared, profile_id, direction, rules
+            )
+            for direction in ("forward", "backward")
+        }
+        for profile_id in HAZARD_PROFILES
+    }
+
+
+def compact_hazard_properties(
+    assessment: Mapping[str, Any], profile_id: str
+) -> dict[str, Any]:
+    directions = assessment[profile_id]
+    forward = directions["forward"]
+    backward = directions["backward"]
+    worst = max(
+        (forward, backward),
+        key=lambda item: (
+            int(item["severity"]),
+            item["traversability"] == "impassable",
+            int(item["confidence"]),
+        ),
+    )
+    categories = {
+        category_id: max(
+            int(forward["categories"][category_id]["severity"]),
+            int(backward["categories"][category_id]["severity"]),
+        )
+        for category_id in HAZARD_CATEGORIES
+    }
+
+    def compact_direction(item: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "severity": int(item["severity"]),
+            "traversability": item["traversability"],
+            "confidence": int(item["confidence"]),
+            "coverage": int(item["coverage"]),
+            "status": item["status"],
+            "rule_ids": item["rule_ids"],
+        }
+
+    return {
+        "severity": int(worst["severity"]),
+        "severity_fwd": int(forward["severity"]),
+        "severity_bwd": int(backward["severity"]),
+        "impact": worst["impact"],
+        "traversability": worst["traversability"],
+        "confidence": int(worst["confidence"]),
+        "coverage": int(worst["coverage"]),
+        "status": worst["status"],
+        "rule_ids": worst["rule_ids"],
+        **{
+            f"category_{category_id}": severity
+            for category_id, severity in categories.items()
+        },
+        "forward": compact_direction(forward),
+        "backward": compact_direction(backward),
+    }

--- a/hazard_analysis/hazard_analysis.html
+++ b/hazard_analysis/hazard_analysis.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OSWM Hazard Analysis</title>
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@6/dist/maplibre-gl.css">
+    <script type="module" src="../assets/branding/branding.js"></script>
+    <link rel="icon" data-oswm-branding="favicon">
+    <style>
+        :root { font-family: Inter, "Helvetica Neue", Arial, sans-serif; color: #1f2933; }
+        * { box-sizing: border-box; }
+        body { margin: 0; }
+        #map { width: 100vw; height: 100vh; }
+        .logo { position: fixed; z-index: 4; top: 7px; left: 7px; width: min(330px, 44vw); }
+        #panel {
+            position: absolute; z-index: 5; top: 16px; right: 48px;
+            width: min(330px, calc(100vw - 76px)); max-height: calc(100vh - 32px);
+            overflow: auto; padding: 15px; border-radius: 12px;
+            background: rgba(255,255,255,.96); box-shadow: 0 5px 20px rgba(0,0,0,.18);
+        }
+        h1 { margin: 0 0 5px; font-size: 20px; }
+        .subtitle, .note { color: #59636e; font-size: 12px; line-height: 1.4; }
+        .control { margin-top: 12px; }
+        label { display: block; margin-bottom: 4px; font-size: 11px; font-weight: 750;
+            letter-spacing: .045em; text-transform: uppercase; }
+        select, input[type="range"] { width: 100%; }
+        select { padding: 7px; border: 1px solid #aeb6bf; border-radius: 6px; background: #fff; }
+        .inline { display: flex; gap: 9px; align-items: center; }
+        .inline input { margin: 0; }
+        .inline label { margin: 0; text-transform: none; letter-spacing: 0; font-size: 13px; }
+        #legend { margin-top: 13px; padding-top: 11px; border-top: 1px solid #d8dde2; }
+        .legend-row { display: flex; align-items: center; gap: 8px; margin: 4px 0; font-size: 12px; }
+        .swatch { width: 28px; height: 5px; border-radius: 3px; }
+        #source { margin-top: 10px; font-size: 10px; color: #65717d; line-height: 1.35; }
+        #loading { display: none; margin-top: 9px; font-size: 12px; font-weight: 700; color: #8a4d00; }
+        #welcome {
+            position: fixed; z-index: 20; inset: 0; display: grid; place-items: center;
+            padding: 20px; background: rgba(14,22,31,.55);
+        }
+        #welcome[hidden] { display: none; }
+        .modal { max-width: 570px; padding: 24px; border-radius: 14px; background: white;
+            box-shadow: 0 10px 35px rgba(0,0,0,.3); }
+        .modal h2 { margin-top: 0; }
+        .modal p, .modal li { font-size: 14px; line-height: 1.5; }
+        button { padding: 9px 15px; border: 0; border-radius: 7px; color: white;
+            background: #165a72; font-weight: 700; cursor: pointer; }
+        .maplibregl-popup-content { max-width: 390px; max-height: 65vh; overflow: auto; }
+        .popup-title { font-weight: 800; font-size: 15px; margin-bottom: 5px; }
+        .badge { display: inline-block; padding: 2px 7px; margin: 2px 3px 2px 0;
+            border-radius: 999px; color: white; font-size: 11px; }
+        .evidence { margin: 7px 0 0; padding-left: 18px; font-size: 12px; }
+        @media (max-width: 650px) {
+            .logo { width: 190px; }
+            #panel { top: auto; bottom: 12px; right: 12px; width: calc(100vw - 24px);
+                max-height: 52vh; }
+        }
+    </style>
+</head>
+<body>
+    <img class="logo" data-oswm-branding="logos.page_dark_clean" alt="OpenSidewalkMap">
+    <div id="map"></div>
+    <aside id="panel">
+        <h1>Hazard Analysis</h1>
+        <div class="subtitle">Evidence-based pedestrian difficulty and danger screening</div>
+        <div class="control">
+            <label for="profileSelect">User profile</label>
+            <select id="profileSelect"></select>
+            <div id="profileDescription" class="note"></div>
+        </div>
+        <div class="control">
+            <label for="categorySelect">Hazard category</label>
+            <select id="categorySelect"><option value="all">All categories</option></select>
+        </div>
+        <div class="control">
+            <label for="severitySelect">Minimum level</label>
+            <select id="severitySelect"></select>
+        </div>
+        <div class="control">
+            <label for="confidenceRange">Minimum confidence: <span id="confidenceValue">0</span>%</label>
+            <input id="confidenceRange" type="range" min="0" max="100" value="0" step="5">
+        </div>
+        <div class="control inline">
+            <input id="unknownToggle" type="checkbox" checked>
+            <label for="unknownToggle">Show insufficient-data features</label>
+        </div>
+        <div class="control inline">
+            <input id="terrainToggle" type="checkbox">
+            <label for="terrainToggle">Terrain difficulty potential</label>
+        </div>
+        <div id="loading">Loading selected profile…</div>
+        <div id="legend"></div>
+        <div id="source"></div>
+    </aside>
+    <div id="welcome">
+        <div class="modal">
+            <h2>Read this map as a screening tool</h2>
+            <p>Hazards are inferred from available OSM attributes and a global terrain model. A feature with no detected hazard is <strong>not certified safe</strong>.</p>
+            <ul>
+                <li>Missing tactile, surface or kerb data remains unknown; it is never treated as “no”.</li>
+                <li>Longitudinal terrain slope is contextual and directional. Cross slope is used only when <code>incline:across=*</code> is explicitly mapped.</li>
+                <li>Surface-material rules are provisional proxies. Critical means either an apparent barrier or an extreme contextual safety risk—the popup states which.</li>
+            </ul>
+            <button id="closeWelcome">Explore the map</button>
+        </div>
+    </div>
+
+    <script src="https://unpkg.com/maplibre-gl@6/dist/maplibre-gl.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js"></script>
+    <script>
+        const DATA_ROOT = "../../data/hazard_analysis";
+        const map = new maplibregl.Map({
+            container: "map",
+            style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+            center: [0, 0], zoom: 2
+        });
+        map.addControl(new maplibregl.NavigationControl(), "top-right");
+
+        const state = { metadata: null, terrain: null, profile: null, cache: new Map(), fitted: false };
+        const $ = id => document.getElementById(id);
+        const escapeHtml = value => String(value ?? "").replace(/[&<>"']/g, char =>
+            ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[char]);
+        const objectValue = value => {
+            if (typeof value !== "string") return value;
+            try { return JSON.parse(value); } catch (_error) { return value; }
+        };
+
+        function setupControls() {
+            Object.entries(state.metadata.profiles).forEach(([id, profile]) => {
+                $("profileSelect").add(new Option(profile.label, id));
+            });
+            Object.entries(state.metadata.categories).forEach(([id, category]) => {
+                $("categorySelect").add(new Option(category.label, id));
+            });
+            Object.entries(state.metadata.severity_levels).forEach(([level, item]) => {
+                $("severitySelect").add(new Option(`${level} — ${item.label}`, level));
+            });
+            $("severitySelect").value = "1";
+            $("legend").innerHTML = Object.entries(state.metadata.severity_levels)
+                .filter(([level]) => level !== "0")
+                .map(([_level, item]) => `<div class="legend-row"><span class="swatch" style="background:${item.color}"></span>${escapeHtml(item.label)}</div>`)
+                .join("") + '<div class="legend-row"><span class="swatch" style="background:#6b7280;border-top:2px dashed white"></span>Insufficient data</div>';
+            for (const id of ["profileSelect", "categorySelect", "severitySelect", "confidenceRange", "unknownToggle"]) {
+                $(id).addEventListener("input", id === "profileSelect" ? loadProfile : applyFilters);
+            }
+            $("terrainToggle").addEventListener("change", updateTerrain);
+        }
+
+        async function loadProfile() {
+            const profile = $("profileSelect").value;
+            state.profile = profile;
+            $("profileDescription").textContent = state.metadata.profiles[profile].description;
+            $("loading").style.display = "block";
+            try {
+                if (!state.cache.has(profile)) {
+                    const response = await fetch(`${DATA_ROOT}/features_${profile}.geojson`);
+                    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                    state.cache.set(profile, await response.json());
+                }
+                const data = state.cache.get(profile);
+                map.getSource("hazards").setData(data);
+                if (!state.fitted && data.features.length) {
+                    map.fitBounds(turf.bbox(data), { padding: 45, maxZoom: 16 });
+                    state.fitted = true;
+                }
+                applyFilters();
+                updateTerrain();
+            } catch (error) {
+                $("loading").textContent = `Could not load profile: ${error.message}`;
+                return;
+            }
+            $("loading").style.display = "none";
+        }
+
+        function applyFilters() {
+            if (!map.getLayer("hazard-lines")) return;
+            const minimum = Number($("severitySelect").value);
+            const confidence = Number($("confidenceRange").value);
+            const category = $("categorySelect").value;
+            $("confidenceValue").textContent = confidence;
+            const severityField = category === "all" ? "severity" : `category_${category}`;
+            const hazardFilter = ["all",
+                ["!=", ["get", "status"], "insufficient_data"],
+                [">=", ["coalesce", ["get", severityField], 0], minimum],
+                [">=", ["coalesce", ["get", "confidence"], 0], confidence]
+            ];
+            map.setFilter("hazard-lines", hazardFilter);
+            map.setFilter("hazard-hit", hazardFilter);
+            map.setLayoutProperty("unknown-lines", "visibility",
+                $("unknownToggle").checked ? "visible" : "none");
+        }
+
+        function updateTerrain() {
+            const visible = $("terrainToggle").checked && state.terrain?.available;
+            if (map.getLayer("terrain-potential")) {
+                map.setLayoutProperty("terrain-potential", "visibility", visible ? "visible" : "none");
+            }
+            if (!visible || !state.profile) return;
+            const profile = state.terrain.profiles[state.profile];
+            const url = `../../${profile.path}`;
+            if (map.getSource("terrain-source")) {
+                map.getSource("terrain-source").updateImage({ url, coordinates: state.terrain.coordinates });
+            }
+        }
+
+        function popupHtml(properties) {
+            const severity = Number(properties.severity);
+            const level = state.metadata.severity_levels[String(severity)];
+            const directionName = Number(properties.severity_fwd) >= Number(properties.severity_bwd) ? "forward" : "backward";
+            const direction = objectValue(properties[directionName]) || {};
+            const impact = objectValue(properties.impact) || [];
+            const ruleIds = objectValue(direction.rule_ids) || [];
+            const rulesById = Object.fromEntries(state.metadata.rules.map(rule => [rule.id, rule]));
+            const evidence = ruleIds.map(ruleId => rulesById[ruleId]).filter(Boolean);
+            const criticalContext = severity === 4
+                ? (properties.traversability === "impassable" ? "Apparent mobility barrier" : "Extreme contextual safety risk")
+                : "";
+            return `<div class="popup-title">${escapeHtml(level.label)}</div>
+                ${criticalContext ? `<div><strong>${escapeHtml(criticalContext)}</strong></div>` : ""}
+                <div>Impact: ${escapeHtml(impact.join?.(", ") || impact || "—")}</div>
+                <div>Traversability: ${escapeHtml(properties.traversability)}</div>
+                <div>Forward / backward: ${properties.severity_fwd} / ${properties.severity_bwd}</div>
+                <div>Confidence: ${properties.confidence}% · evidence coverage: ${properties.coverage}%</div>
+                <div>Status: ${escapeHtml(properties.status)} · slope: ${escapeHtml(properties.slope_source)}</div>
+                <div>Feature: ${escapeHtml(properties.edge_kind)} · ${escapeHtml(properties.source_id)}</div>
+                <ul class="evidence">${evidence.map(item =>
+                    `<li><span class="badge" style="background:${state.metadata.severity_levels[String(item.effects[state.profile].severity)].color}">${escapeHtml(state.metadata.categories[item.category].label)}</span> ${escapeHtml(item.description)}</li>`
+                ).join("") || "<li>No hazard rule matched the available evidence.</li>"}</ul>`;
+        }
+
+        async function initialise() {
+            [state.metadata, state.terrain] = await Promise.all([
+                fetch(`${DATA_ROOT}/profiles.json`).then(response => response.json()),
+                fetch(`${DATA_ROOT}/terrain.json`).then(response => response.json())
+            ]);
+            setupControls();
+            $("source").innerHTML = state.terrain.available
+                ? `${escapeHtml(state.terrain.description)}<br>${escapeHtml(state.terrain.source_attribution)}`
+                : "Terrain overlay unavailable for this generation.";
+
+            const addLayers = () => {
+                if (map.getSource("hazards")) return;
+                map.addSource("terrain-source", {
+                    type: "image",
+                    url: "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=",
+                    coordinates: state.terrain.coordinates || [[0,0],[0,0],[0,0],[0,0]]
+                });
+                map.addLayer({ id: "terrain-potential", type: "raster", source: "terrain-source",
+                    layout: { visibility: "none" }, paint: { "raster-opacity": .7 } });
+                map.addSource("hazards", { type: "geojson", data: { type: "FeatureCollection", features: [] } });
+                map.addLayer({ id: "unknown-lines", type: "line", source: "hazards",
+                    filter: ["==", ["get", "status"], "insufficient_data"],
+                    paint: { "line-color": "#6b7280", "line-width": 2, "line-dasharray": [2,2], "line-opacity": .55 } });
+                map.addLayer({ id: "hazard-lines", type: "line", source: "hazards",
+                    paint: {
+                        "line-color": ["match", ["get", "severity"], 1,"#fee08b",2,"#fdae61",3,"#f46d43",4,"#a50026","#4daf4a"],
+                        "line-width": ["interpolate", ["linear"], ["zoom"], 10, 1.5, 17, 6],
+                        "line-opacity": .9
+                    }});
+                map.addLayer({ id: "hazard-hit", type: "line", source: "hazards",
+                    paint: { "line-color": "rgba(0,0,0,0)", "line-width": 14 } });
+                map.on("click", "hazard-hit", event => {
+                    const feature = event.features[0];
+                    new maplibregl.Popup().setLngLat(event.lngLat)
+                        .setHTML(popupHtml(feature.properties)).addTo(map);
+                });
+                map.on("mouseenter", "hazard-hit", () => map.getCanvas().style.cursor = "pointer");
+                map.on("mouseleave", "hazard-hit", () => map.getCanvas().style.cursor = "");
+                loadProfile();
+            };
+            if (map.isStyleLoaded()) addLayers(); else map.once("load", addLayers);
+        }
+
+        $("closeWelcome").addEventListener("click", () => $("welcome").hidden = true);
+        initialise().catch(error => {
+            $("loading").style.display = "block";
+            $("loading").textContent = `Module metadata unavailable: ${error.message}`;
+        });
+    </script>
+</body>
+</html>

--- a/hazard_analysis/rules.py
+++ b/hazard_analysis/rules.py
@@ -1,0 +1,578 @@
+"""Human-editable pedestrian hazard policy.
+
+These rules are deliberately provisional. Severity is not a probability and
+must never be interpreted as proof that an unflagged feature is safe.
+"""
+
+from __future__ import annotations
+
+
+HAZARD_RULESET_VERSION = "0.1.0"
+
+SEVERITY_LEVELS = {
+    0: {
+        "label": "No detected hazard",
+        "color": "#4daf4a",
+        "description": "No rule matched the available evidence.",
+    },
+    1: {
+        "label": "Uncomfortable",
+        "color": "#fee08b",
+        "description": "May reduce comfort or require additional effort.",
+    },
+    2: {
+        "label": "Unfavorable",
+        "color": "#fdae61",
+        "description": "Meaningfully degrades pedestrian accessibility.",
+    },
+    3: {
+        "label": "Dangerous",
+        "color": "#f46d43",
+        "description": "May create a serious safety or mobility hazard.",
+    },
+    4: {
+        "label": "Critical",
+        "color": "#a50026",
+        "description": "Potential barrier or extreme contextual safety risk.",
+    },
+}
+
+HAZARD_CATEGORIES = {
+    "longitudinal_slope": {
+        "label": "Longitudinal slope",
+        "description": "Directional terrain or explicitly mapped incline.",
+    },
+    "cross_slope": {
+        "label": "Cross slope",
+        "description": "Only explicit OSM incline:across evidence.",
+    },
+    "kerb": {
+        "label": "Kerb transition",
+        "description": "Kerb height/type and transition traversability.",
+    },
+    "tactile_orientation": {
+        "label": "Tactile and orientation",
+        "description": "Tactile evidence and detectable material transitions.",
+    },
+    "surface": {
+        "label": "Surface",
+        "description": "Smoothness plus provisional surface-material proxies.",
+    },
+    "barrier": {
+        "label": "Barrier",
+        "description": "Explicit or strongly inferred traversal barriers.",
+    },
+}
+
+HAZARD_PROFILES = {
+    "pedestrian": {
+        "label": "Pedestrian",
+        "description": "General walking comfort and safety.",
+    },
+    "wheelchair": {
+        "label": "Wheelchair user",
+        "description": "Continuous rollable access with manageable gradients.",
+    },
+    "blind": {
+        "label": "Blind or low-vision pedestrian",
+        "description": "Detectable, orientable and predictable transitions.",
+    },
+    "elderly": {
+        "label": "Older or reduced-mobility pedestrian",
+        "description": "Stability, effort and fall-risk oriented assessment.",
+    },
+}
+
+
+def _effect(
+    severity: int,
+    impact: str,
+    traversability: str = "passable",
+) -> dict[str, object]:
+    return {
+        "severity": severity,
+        "impact": impact,
+        "traversability": traversability,
+    }
+
+
+HAZARD_RULES = [
+    {
+        "id": "barrier_steps",
+        "category": "barrier",
+        "description": "Steps interrupt step-free movement.",
+        "confidence": 95,
+        "condition": {"field": "highway", "operator": "equals", "value": "steps"},
+        "effects": {
+            "pedestrian": _effect(1, "Additional effort"),
+            "wheelchair": _effect(4, "Step-free passage blocked", "impassable"),
+            "blind": _effect(2, "Level change requires care"),
+            "elderly": _effect(3, "High effort and fall risk"),
+        },
+    },
+    {
+        "id": "barrier_wheelchair_no",
+        "category": "barrier",
+        "description": "OSM explicitly marks wheelchair access as unavailable.",
+        "confidence": 95,
+        "condition": {"field": "wheelchair", "operator": "equals", "value": "no"},
+        "effects": {
+            "wheelchair": _effect(4, "Wheelchair access explicitly blocked", "impassable")
+        },
+    },
+    {
+        "id": "surface_impassable",
+        "category": "barrier",
+        "description": "OSM explicitly describes the surface as impassable.",
+        "confidence": 95,
+        "condition": {
+            "field": "smoothness",
+            "operator": "equals",
+            "value": "impassable",
+        },
+        "effects": {
+            "pedestrian": _effect(4, "Passage explicitly impassable", "impassable"),
+            "wheelchair": _effect(4, "Passage explicitly impassable", "impassable"),
+            "blind": _effect(4, "Passage explicitly impassable", "impassable"),
+            "elderly": _effect(4, "Passage explicitly impassable", "impassable"),
+        },
+    },
+    {
+        "id": "kerb_raised",
+        "category": "kerb",
+        "description": "A raised kerb is associated with the crossing.",
+        "confidence": 90,
+        "applies_to": ["crossing"],
+        "condition": {
+            "field": "associated_kerbs",
+            "operator": "contains",
+            "value": "raised",
+        },
+        "effects": {
+            "pedestrian": _effect(1, "Abrupt level change"),
+            "wheelchair": _effect(4, "Kerb blocks independent passage", "impassable"),
+            "elderly": _effect(3, "Trip and fall hazard"),
+        },
+    },
+    {
+        "id": "kerb_ambiguous_yes",
+        "category": "kerb",
+        "description": "A kerb is mapped without a traversable kerb type.",
+        "confidence": 70,
+        "applies_to": ["crossing"],
+        "condition": {
+            "field": "associated_kerbs",
+            "operator": "contains",
+            "value": "yes",
+        },
+        "effects": {
+            "wheelchair": _effect(3, "Kerb traversability uncertain"),
+            "elderly": _effect(2, "Potential abrupt level change"),
+        },
+    },
+    {
+        "id": "kerb_rolled",
+        "category": "kerb",
+        "description": "A rolled kerb can still require substantial effort.",
+        "confidence": 85,
+        "applies_to": ["crossing"],
+        "condition": {
+            "field": "associated_kerbs",
+            "operator": "contains",
+            "value": "rolled",
+        },
+        "effects": {
+            "wheelchair": _effect(2, "Difficult rolling transition"),
+            "blind": _effect(1, "Weakly defined transition"),
+            "elderly": _effect(2, "Unstable transition"),
+        },
+    },
+    {
+        "id": "flush_without_tactile",
+        "category": "tactile_orientation",
+        "description": "A flush kerb is explicitly paired with absent tactile paving.",
+        "confidence": 95,
+        "applies_to": ["crossing"],
+        "condition": {
+            "field": "associated_transition_states",
+            "operator": "transition_pair",
+            "kerb": "flush",
+            "tactile_paving": "no",
+        },
+        "effects": {
+            "blind": _effect(
+                4,
+                "Street boundary may be undetectable",
+                "passable_with_extreme_risk",
+            ),
+            "elderly": _effect(1, "Transition lacks tactile cue"),
+        },
+    },
+    {
+        "id": "lowered_without_tactile",
+        "category": "tactile_orientation",
+        "description": "A lowered kerb is explicitly paired with absent tactile paving.",
+        "confidence": 90,
+        "applies_to": ["crossing"],
+        "condition": {
+            "field": "associated_transition_states",
+            "operator": "transition_pair",
+            "kerb": "lowered",
+            "tactile_paving": "no",
+        },
+        "effects": {
+            "blind": _effect(3, "Street boundary has weak tactile detection"),
+        },
+    },
+    {
+        "id": "crossing_tactile_no",
+        "category": "tactile_orientation",
+        "description": "Tactile paving is explicitly absent at the crossing.",
+        "confidence": 90,
+        "applies_to": ["crossing"],
+        "condition": {
+            "field": "associated_tactile_paving",
+            "operator": "contains",
+            "value": "no",
+        },
+        "effects": {
+            "blind": _effect(3, "No mapped tactile warning at street transition"),
+        },
+    },
+    {
+        "id": "uniform_transition_surface",
+        "category": "tactile_orientation",
+        "description": (
+            "Crossing, kerb and adjacent sidewalk share one explicitly mapped "
+            "surface; this is a low-confidence detectability proxy."
+        ),
+        "confidence": 45,
+        "applies_to": ["crossing"],
+        "condition": {
+            "field": "uniform_transition_surface",
+            "operator": "equals",
+            "value": True,
+        },
+        "effects": {
+            "blind": _effect(3, "Material transition may be difficult to detect"),
+        },
+    },
+    {
+        "id": "smoothness_very_horrible",
+        "category": "surface",
+        "description": "Very horrible smoothness indicates an extreme unevenness.",
+        "confidence": 90,
+        "condition": {
+            "field": "smoothness",
+            "operator": "equals",
+            "value": "very_horrible",
+        },
+        "effects": {
+            "pedestrian": _effect(3, "Extreme unevenness"),
+            "wheelchair": _effect(4, "Independent rolling may be impossible", "impassable"),
+            "blind": _effect(3, "Severe trip and orientation hazard"),
+            "elderly": _effect(4, "Extreme fall risk", "passable_with_extreme_risk"),
+        },
+    },
+    {
+        "id": "smoothness_horrible",
+        "category": "surface",
+        "description": "Horrible smoothness indicates severe unevenness.",
+        "confidence": 90,
+        "condition": {
+            "field": "smoothness",
+            "operator": "equals",
+            "value": "horrible",
+        },
+        "effects": {
+            "pedestrian": _effect(2, "Severe unevenness"),
+            "wheelchair": _effect(4, "Rolling may be effectively blocked", "impassable"),
+            "blind": _effect(3, "Severe trip hazard"),
+            "elderly": _effect(3, "High fall risk"),
+        },
+    },
+    {
+        "id": "smoothness_very_bad",
+        "category": "surface",
+        "description": "Very bad smoothness creates substantial mobility difficulty.",
+        "confidence": 90,
+        "condition": {
+            "field": "smoothness",
+            "operator": "equals",
+            "value": "very_bad",
+        },
+        "effects": {
+            "pedestrian": _effect(2, "Substantial unevenness"),
+            "wheelchair": _effect(3, "Very difficult rolling surface"),
+            "blind": _effect(2, "Substantial trip hazard"),
+            "elderly": _effect(3, "High instability"),
+        },
+    },
+    {
+        "id": "smoothness_bad",
+        "category": "surface",
+        "description": "Bad smoothness creates a meaningful mobility penalty.",
+        "confidence": 90,
+        "condition": {
+            "field": "smoothness",
+            "operator": "equals",
+            "value": "bad",
+        },
+        "effects": {
+            "pedestrian": _effect(1, "Uneven walking surface"),
+            "wheelchair": _effect(2, "Difficult rolling surface"),
+            "blind": _effect(2, "Trip hazard"),
+            "elderly": _effect(2, "Instability and fall risk"),
+        },
+    },
+    {
+        "id": "surface_sand",
+        "category": "surface",
+        "description": "Surface material is a provisional mobility proxy.",
+        "confidence": 55,
+        "condition": {"field": "surface", "operator": "equals", "value": "sand"},
+        "effects": {
+            "pedestrian": _effect(2, "Loose surface"),
+            "wheelchair": _effect(4, "Wheels may become immobilized", "impassable"),
+            "blind": _effect(2, "Unstable surface"),
+            "elderly": _effect(3, "High instability"),
+        },
+    },
+    {
+        "id": "surface_grass",
+        "category": "surface",
+        "description": "Surface material is a provisional mobility proxy.",
+        "confidence": 55,
+        "condition": {"field": "surface", "operator": "equals", "value": "grass"},
+        "effects": {
+            "pedestrian": _effect(1, "Variable natural surface"),
+            "wheelchair": _effect(3, "High rolling resistance"),
+            "blind": _effect(1, "Variable surface"),
+            "elderly": _effect(2, "Unstable footing"),
+        },
+    },
+    {
+        "id": "surface_ground_earth_dirt",
+        "category": "surface",
+        "description": "Surface material is a provisional mobility proxy.",
+        "confidence": 55,
+        "condition": {
+            "field": "surface",
+            "operator": "in",
+            "value": ["ground", "earth", "dirt", "unpaved"],
+        },
+        "effects": {
+            "pedestrian": _effect(1, "Weather-sensitive surface"),
+            "wheelchair": _effect(3, "High or variable rolling resistance"),
+            "blind": _effect(1, "Irregular surface"),
+            "elderly": _effect(2, "Unstable footing"),
+        },
+    },
+    {
+        "id": "surface_gravel",
+        "category": "surface",
+        "description": "Surface material is a provisional mobility proxy.",
+        "confidence": 55,
+        "condition": {"field": "surface", "operator": "equals", "value": "gravel"},
+        "effects": {
+            "pedestrian": _effect(1, "Loose aggregate"),
+            "wheelchair": _effect(3, "Difficult rolling surface"),
+            "blind": _effect(1, "Loose aggregate"),
+            "elderly": _effect(2, "Unstable footing"),
+        },
+    },
+    {
+        "id": "surface_cobble_sett",
+        "category": "surface",
+        "description": "Surface material is a provisional mobility proxy.",
+        "confidence": 55,
+        "condition": {
+            "field": "surface",
+            "operator": "in",
+            "value": ["cobblestone", "unhewn_cobblestone", "sett"],
+        },
+        "effects": {
+            "pedestrian": _effect(1, "Uneven joints"),
+            "wheelchair": _effect(3, "Difficult vibration-heavy rolling"),
+            "blind": _effect(2, "Irregular trip-prone surface"),
+            "elderly": _effect(2, "Trip and instability hazard"),
+        },
+    },
+    {
+        "id": "surface_compacted_fine_gravel",
+        "category": "surface",
+        "description": "Surface material is a provisional mobility proxy.",
+        "confidence": 50,
+        "condition": {
+            "field": "surface",
+            "operator": "in",
+            "value": ["compacted", "fine_gravel"],
+        },
+        "effects": {
+            "wheelchair": _effect(2, "Increased rolling resistance"),
+            "elderly": _effect(1, "Potentially loose footing"),
+        },
+    },
+    {
+        "id": "cross_slope_over_5",
+        "category": "cross_slope",
+        "description": "Explicit cross slope exceeds 5%.",
+        "confidence": 95,
+        "condition": {
+            "field": "cross_slope_percent",
+            "operator": "abs_gt",
+            "value": 5,
+        },
+        "effects": {
+            "pedestrian": _effect(2, "Strong lateral imbalance"),
+            "wheelchair": _effect(4, "High tip or drift risk", "passable_with_extreme_risk"),
+            "blind": _effect(2, "Strong lateral imbalance"),
+            "elderly": _effect(3, "High fall risk"),
+        },
+    },
+    {
+        "id": "cross_slope_3_to_5",
+        "category": "cross_slope",
+        "description": "Explicit cross slope is greater than 3% and at most 5%.",
+        "confidence": 95,
+        "condition": {
+            "field": "cross_slope_percent",
+            "operator": "abs_range",
+            "min_exclusive": 3,
+            "max_inclusive": 5,
+        },
+        "effects": {
+            "pedestrian": _effect(1, "Lateral imbalance"),
+            "wheelchair": _effect(3, "Substantial drift or tip risk"),
+            "blind": _effect(1, "Lateral imbalance"),
+            "elderly": _effect(2, "Instability"),
+        },
+    },
+    {
+        "id": "cross_slope_2_to_3",
+        "category": "cross_slope",
+        "description": "Explicit cross slope is greater than 2% and at most 3%.",
+        "confidence": 95,
+        "condition": {
+            "field": "cross_slope_percent",
+            "operator": "abs_range",
+            "min_exclusive": 2,
+            "max_inclusive": 3,
+        },
+        "effects": {
+            "wheelchair": _effect(2, "Noticeable lateral effort"),
+            "elderly": _effect(1, "Mild lateral instability"),
+        },
+    },
+    {
+        "id": "uphill_over_12_5",
+        "category": "longitudinal_slope",
+        "description": "Travel direction rises by more than 12.5%.",
+        "confidence": 80,
+        "directional": True,
+        "condition": {
+            "field": "directional_incline_percent",
+            "operator": "gt",
+            "value": 12.5,
+        },
+        "effects": {
+            "pedestrian": _effect(3, "Extreme climbing effort"),
+            "wheelchair": _effect(4, "Independent ascent may be impossible", "impassable"),
+            "blind": _effect(2, "Extreme climbing effort"),
+            "elderly": _effect(4, "Extreme exertion and fall risk", "passable_with_extreme_risk"),
+        },
+    },
+    {
+        "id": "uphill_8_33_to_12_5",
+        "category": "longitudinal_slope",
+        "description": "Travel direction rises by more than 8.33% and at most 12.5%.",
+        "confidence": 80,
+        "directional": True,
+        "condition": {
+            "field": "directional_incline_percent",
+            "operator": "range",
+            "min_exclusive": 8.33,
+            "max_inclusive": 12.5,
+        },
+        "effects": {
+            "pedestrian": _effect(2, "High climbing effort"),
+            "wheelchair": _effect(3, "Very difficult ascent"),
+            "blind": _effect(1, "High climbing effort"),
+            "elderly": _effect(3, "High exertion"),
+        },
+    },
+    {
+        "id": "uphill_5_to_8_33",
+        "category": "longitudinal_slope",
+        "description": "Travel direction rises by more than 5% and at most 8.33%.",
+        "confidence": 80,
+        "directional": True,
+        "condition": {
+            "field": "directional_incline_percent",
+            "operator": "range",
+            "min_exclusive": 5,
+            "max_inclusive": 8.33,
+        },
+        "effects": {
+            "pedestrian": _effect(1, "Increased climbing effort"),
+            "wheelchair": _effect(2, "Difficult ascent"),
+            "elderly": _effect(2, "Increased exertion"),
+        },
+    },
+    {
+        "id": "downhill_over_12_5",
+        "category": "longitudinal_slope",
+        "description": "Travel direction descends by more than 12.5%.",
+        "confidence": 80,
+        "directional": True,
+        "condition": {
+            "field": "directional_incline_percent",
+            "operator": "lt",
+            "value": -12.5,
+        },
+        "effects": {
+            "pedestrian": _effect(3, "Extreme braking and fall risk"),
+            "wheelchair": _effect(4, "Loss-of-control risk", "passable_with_extreme_risk"),
+            "blind": _effect(3, "Extreme descent hazard"),
+            "elderly": _effect(4, "Extreme fall risk", "passable_with_extreme_risk"),
+        },
+    },
+    {
+        "id": "downhill_8_33_to_12_5",
+        "category": "longitudinal_slope",
+        "description": "Travel direction descends by more than 8.33% and at most 12.5%.",
+        "confidence": 80,
+        "directional": True,
+        "condition": {
+            "field": "directional_incline_percent",
+            "operator": "negative_range",
+            "min_abs_exclusive": 8.33,
+            "max_abs_inclusive": 12.5,
+        },
+        "effects": {
+            "pedestrian": _effect(2, "High braking effort"),
+            "wheelchair": _effect(3, "Substantial loss-of-control risk"),
+            "blind": _effect(2, "Steep descent hazard"),
+            "elderly": _effect(3, "High fall risk"),
+        },
+    },
+    {
+        "id": "downhill_5_to_8_33",
+        "category": "longitudinal_slope",
+        "description": "Travel direction descends by more than 5% and at most 8.33%.",
+        "confidence": 80,
+        "directional": True,
+        "condition": {
+            "field": "directional_incline_percent",
+            "operator": "negative_range",
+            "min_abs_exclusive": 5,
+            "max_abs_inclusive": 8.33,
+        },
+        "effects": {
+            "pedestrian": _effect(1, "Increased braking effort"),
+            "wheelchair": _effect(2, "Difficult controlled descent"),
+            "blind": _effect(1, "Increased descent care"),
+            "elderly": _effect(2, "Increased fall risk"),
+        },
+    },
+]

--- a/hazard_analysis/terrain.py
+++ b/hazard_analysis/terrain.py
@@ -1,0 +1,284 @@
+"""Generate contextual terrain-difficulty overlays from global AWS DEM tiles."""
+
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from routing.elevation import (
+    CopernicusGLO30Provider,
+    CopernicusGLO90Provider,
+)
+
+
+COPERNICUS_LICENSE_URL = (
+    "https://dataspace.copernicus.eu/explore-data/data-collections/"
+    "copernicus-contributing-missions/collections-description/COP-DEM"
+)
+COPERNICUS_SOURCES = {
+    "copernicus_glo30": {
+        "title": "Copernicus DEM GLO-30 Public (2021)",
+        "resolution_m": 30,
+        "source_url": "https://registry.opendata.aws/copernicus-dem/",
+        "license": "Copernicus DEM free licence",
+        "license_url": COPERNICUS_LICENSE_URL,
+        "attribution": (
+            "Produced using Copernicus WorldDEM-30 © DLR e.V. 2010–2014 "
+            "and © Airbus Defence and Space GmbH 2014–2018 provided under "
+            "COPERNICUS by the European Union and ESA; all rights reserved."
+        ),
+    },
+    "copernicus_glo90": {
+        "title": "Copernicus DEM GLO-90 (2021)",
+        "resolution_m": 90,
+        "source_url": "https://registry.opendata.aws/copernicus-dem/",
+        "license": "Copernicus DEM free licence",
+        "license_url": COPERNICUS_LICENSE_URL,
+        "attribution": (
+            "Produced using Copernicus WorldDEM-90 © DLR e.V. 2010–2014 "
+            "and © Airbus Defence and Space GmbH 2014–2018 provided under "
+            "COPERNICUS by the European Union and ESA; all rights reserved."
+        ),
+    },
+}
+
+TERRAIN_THRESHOLDS = {
+    "pedestrian": [5.0, 8.33, 12.5, 20.0],
+    "wheelchair": [2.0, 5.0, 8.33, 12.5],
+    "blind": [5.0, 8.33, 12.5, 20.0],
+    "elderly": [2.0, 5.0, 8.33, 12.5],
+}
+
+_RGBA = {
+    0: (0, 0, 0, 0),
+    1: (254, 224, 139, 105),
+    2: (253, 174, 97, 145),
+    3: (244, 109, 67, 180),
+    4: (165, 0, 38, 215),
+}
+
+
+def classify_terrain_slope(
+    slope_percent: Any, thresholds: list[float]
+):
+    """Classify unsigned slope potential into hazard severity 0..4."""
+
+    import numpy as np
+
+    slope = np.asarray(slope_percent, dtype="float32")
+    result = np.zeros(slope.shape, dtype="uint8")
+    for severity, threshold in enumerate(thresholds, start=1):
+        result[slope > threshold] = severity
+    result[~np.isfinite(slope)] = 0
+    return result
+
+
+def _smooth_nan(array, sigma: float):
+    import numpy as np
+
+    if sigma <= 0:
+        return array
+    radius = max(1, int(math.ceil(sigma * 3)))
+    offsets = np.arange(-radius, radius + 1, dtype="float32")
+    kernel = np.exp(-(offsets**2) / (2 * sigma**2))
+    kernel /= kernel.sum()
+    valid = np.isfinite(array).astype("float32")
+    values = np.nan_to_num(array, nan=0.0).astype("float32")
+
+    def convolve(data, axis):
+        return np.apply_along_axis(
+            lambda row: np.convolve(row, kernel, mode="same"), axis, data
+        )
+
+    weighted = convolve(convolve(values, 1), 0)
+    weights = convolve(convolve(valid, 1), 0)
+    return np.divide(
+        weighted,
+        weights,
+        out=np.full_like(weighted, np.nan),
+        where=weights > 1e-6,
+    )
+
+
+def _candidate_tiles(bounds: tuple[float, float, float, float]):
+    minx, miny, maxx, maxy = bounds
+    for south in range(math.floor(miny), math.ceil(maxy)):
+        for west in range(math.floor(minx), math.ceil(maxx)):
+            yield south + 0.5, west + 0.5
+
+
+def _provider_from_config(config: dict[str, Any], timeout: int):
+    provider_type = config.get("type")
+    if provider_type == "copernicus_glo30":
+        return CopernicusGLO30Provider(config, timeout)
+    if provider_type == "copernicus_glo90":
+        return CopernicusGLO90Provider(config, timeout)
+    return None
+
+
+def _read_provider_window(
+    provider,
+    bounds: tuple[float, float, float, float],
+    max_dimension: int,
+):
+    import numpy as np
+    import rasterio
+    from rasterio.enums import Resampling
+    from rasterio.merge import merge
+
+    paths = [
+        provider._local_tile(latitude, longitude)
+        for latitude, longitude in _candidate_tiles(bounds)
+    ]
+    datasets = [rasterio.open(path) for path in paths]
+    try:
+        native_x = min(abs(dataset.transform.a) for dataset in datasets)
+        native_y = min(abs(dataset.transform.e) for dataset in datasets)
+        estimated_width = (bounds[2] - bounds[0]) / native_x
+        estimated_height = (bounds[3] - bounds[1]) / native_y
+        scale = max(1.0, estimated_width / max_dimension, estimated_height / max_dimension)
+        data, transform = merge(
+            datasets,
+            bounds=bounds,
+            res=(native_x * scale, native_y * scale),
+            nodata=np.nan,
+            dtype="float32",
+            resampling=Resampling.bilinear,
+        )
+        return data[0], transform
+    finally:
+        for dataset in datasets:
+            dataset.close()
+
+
+def _atomic_png(path: Path, rgba) -> None:
+    from PIL import Image
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp.png",
+        delete=False,
+    )
+    temporary = Path(handle.name)
+    handle.close()
+    try:
+        Image.fromarray(rgba, mode="RGBA").save(temporary, "PNG", optimize=True)
+        with Image.open(temporary) as check:
+            check.verify()
+        os.replace(temporary, path)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def generate_terrain_overlays(
+    bounds: tuple[float, float, float, float],
+    elevation_config: dict[str, Any],
+    terrain_config: dict[str, Any],
+    output_dir: str | os.PathLike[str],
+) -> dict[str, Any]:
+    """Render one transparent contextual terrain layer per user profile."""
+
+    import numpy as np
+
+    if not terrain_config.get("enabled", True):
+        return {
+            "schema_version": 1,
+            "available": False,
+            "reason": "terrain overlay disabled by node configuration",
+        }
+
+    timeout = int(elevation_config.get("request_timeout_seconds", 120))
+    provider_configs = sorted(
+        elevation_config.get("providers", []),
+        key=lambda item: item.get("priority", 0),
+        reverse=True,
+    )
+    max_dimension = int(terrain_config.get("max_dimension", 1600))
+    sigma = float(terrain_config.get("smoothing_sigma_pixels", 3.0))
+    failures: list[str] = []
+    provider = None
+    elevation = transform = None
+    for config in provider_configs:
+        candidate = _provider_from_config(config, timeout)
+        if candidate is None:
+            continue
+        try:
+            elevation, transform = _read_provider_window(
+                candidate, bounds, max_dimension
+            )
+        except Exception as exc:
+            failures.append(
+                f"{candidate.source_name}: {type(exc).__name__}: {exc}"
+            )
+            continue
+        provider = candidate
+        break
+
+    if provider is None or elevation is None or transform is None:
+        return {
+            "schema_version": 1,
+            "available": False,
+            "reason": "no global elevation provider covered this node",
+            "provider_failures": failures,
+        }
+
+    elevation = _smooth_nan(elevation, sigma)
+    latitude = (bounds[1] + bounds[3]) / 2
+    x_metres = abs(transform.a) * 111_320 * max(
+        0.01, math.cos(math.radians(latitude))
+    )
+    y_metres = abs(transform.e) * 110_574
+    gradient_y, gradient_x = np.gradient(elevation, y_metres, x_metres)
+    slope_percent = np.hypot(gradient_x, gradient_y) * 100
+
+    output_path = Path(output_dir)
+    profile_metadata = {}
+    for profile_id, thresholds in TERRAIN_THRESHOLDS.items():
+        severity = classify_terrain_slope(slope_percent, thresholds)
+        rgba = np.zeros((*severity.shape, 4), dtype="uint8")
+        for level, color in _RGBA.items():
+            rgba[severity == level] = color
+        filename = f"terrain_{profile_id}.png"
+        _atomic_png(output_path / filename, rgba)
+        profile_metadata[profile_id] = {
+            "path": f"data/hazard_analysis/{filename}",
+            "thresholds_percent": thresholds,
+        }
+
+    source = COPERNICUS_SOURCES[provider.source_name]
+    return {
+        "schema_version": 1,
+        "available": True,
+        "title": "Terrain difficulty potential",
+        "description": (
+            "Contextual unsigned slope potential derived from a global digital "
+            "surface model. It is not a measurement of sidewalk or cross slope."
+        ),
+        "source_name": provider.source_name,
+        "source_title": source["title"],
+        "source_url": source["source_url"],
+        "source_attribution": source["attribution"],
+        "license": source["license"],
+        "license_url": source["license_url"],
+        "resolution_m": source["resolution_m"],
+        "bounds": list(bounds),
+        "coordinates": [
+            [bounds[0], bounds[3]],
+            [bounds[2], bounds[3]],
+            [bounds[2], bounds[1]],
+            [bounds[0], bounds[1]],
+        ],
+        "width": int(elevation.shape[1]),
+        "height": int(elevation.shape[0]),
+        "directionality": "unsigned contextual potential",
+        "cross_slope_included": False,
+        "smoothing_sigma_pixels": sigma,
+        "profiles": profile_metadata,
+        "provider_failures": failures,
+    }

--- a/hazard_analysis/validation.py
+++ b/hazard_analysis/validation.py
@@ -1,0 +1,80 @@
+"""Validation and browser-safe publication for hazard policy dictionaries."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .rules import HAZARD_CATEGORIES, HAZARD_PROFILES, SEVERITY_LEVELS
+
+
+def validate_rules(rules: Sequence[Mapping[str, Any]]) -> None:
+    seen: set[str] = set()
+    for index, rule in enumerate(rules):
+        rule_id = rule.get("id")
+        if not isinstance(rule_id, str) or not rule_id:
+            raise ValueError(f"hazard rule {index} has no valid id")
+        if rule_id in seen:
+            raise ValueError(f"duplicate hazard rule id: {rule_id}")
+        seen.add(rule_id)
+
+        if rule.get("category") not in HAZARD_CATEGORIES:
+            raise ValueError(f"{rule_id}: unknown category")
+        confidence = rule.get("confidence")
+        if not isinstance(confidence, int) or not 0 <= confidence <= 100:
+            raise ValueError(f"{rule_id}: confidence must be an integer 0..100")
+        if not isinstance(rule.get("condition"), Mapping):
+            raise ValueError(f"{rule_id}: condition must be a mapping")
+        applies_to = rule.get("applies_to", [])
+        if not isinstance(applies_to, Sequence) or isinstance(applies_to, str):
+            raise ValueError(f"{rule_id}: applies_to must be a sequence")
+
+        effects = rule.get("effects")
+        if not isinstance(effects, Mapping) or not effects:
+            raise ValueError(f"{rule_id}: effects must not be empty")
+        for profile_id, effect in effects.items():
+            if profile_id not in HAZARD_PROFILES:
+                raise ValueError(f"{rule_id}: unknown profile {profile_id}")
+            if not isinstance(effect, Mapping):
+                raise ValueError(f"{rule_id}: invalid effect for {profile_id}")
+            severity = effect.get("severity")
+            if severity not in SEVERITY_LEVELS or severity == 0:
+                raise ValueError(f"{rule_id}: invalid nonzero severity")
+            if not effect.get("impact"):
+                raise ValueError(f"{rule_id}: effect requires an impact")
+            if effect.get("traversability") not in {
+                "passable",
+                "passable_with_extreme_risk",
+                "impassable",
+            }:
+                raise ValueError(f"{rule_id}: invalid traversability")
+
+
+def ruleset_hash(rules: Sequence[Mapping[str, Any]]) -> str:
+    encoded = json.dumps(
+        list(rules),
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def public_rule_metadata(
+    rules: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Publish explanations and effects, never executable conditions."""
+
+    return [
+        {
+            "id": rule["id"],
+            "category": rule["category"],
+            "description": rule["description"],
+            "confidence": rule["confidence"],
+            "directional": bool(rule.get("directional")),
+            "effects": rule["effects"],
+        }
+        for rule in rules
+    ]

--- a/modules_info.py
+++ b/modules_info.py
@@ -19,6 +19,11 @@ modules_metadata = {
         "img_src": f"{assets_homepage_path}oswm_route_img.png",
         "text": "Routing Demo",
     },
+    "hazard_analysis": {
+        "url": "oswm_codebase/hazard_analysis/hazard_analysis.html",
+        "img_src": f"{assets_homepage_path}oswm_hazard_img.svg",
+        "text": "Hazard Analysis",
+    },
     "dashboard": {
         "url": "statistics/index.html",
         "img_src": f"{assets_homepage_path}oswm_statistics_img.png",
@@ -45,16 +50,15 @@ for modulename in modules_metadata:
     text = modules_metadata[modulename]["text"]
 
     modules_as_str += f"""
-    
+
     <div class="{outer_div_class_ref}">
 
-
     <a href="{url}">
-        
-        <img title="OSWM {modulename}" 
-        src="{img_src}" 
+
+        <img title="OSWM {modulename}"
+        src="{img_src}"
         alt="OSWM {modulename} image" class="{img_css_class_ref}">
-    
+
         <!-- THX: https://jsfiddle.net/Venugopal/e0u4sow1/1/ -->
 
         <div class="{inner_div_class_ref}">
@@ -63,9 +67,8 @@ for modulename in modules_metadata:
 
         </div>
 
-    </a> 
+    </a>
 
     </div>
     <p></p>
-        
-    """
+    """.rstrip() + "\n"

--- a/other/templates/config.py
+++ b/other/templates/config.py
@@ -53,7 +53,9 @@ TILES_MAX_ZOOM = 20
 #
 # OSM incline=* values always have priority. The providers below are tried in
 # descending priority order only when a numeric mapped incline is unavailable.
-# A node can insert a local LiDAR/DTM COG before the global fallback:
+# The default is globally valid: public Copernicus DEM COGs hosted by AWS,
+# with GLO-30 preferred and worldwide GLO-90 used for any unreleased 30 m
+# tile. A node may still insert a better local LiDAR/DTM COG before them:
 #
 # {
 #     "type": "local_cog",
@@ -73,15 +75,30 @@ ELEVATION_CONFIG = {
     "providers": [
         {
             "type": "copernicus_glo30",
-            "role": "global_fallback",
-            "priority": 10,
+            "role": "global_primary",
+            "priority": 20,
             "cache_dir": ".cache/oswm/elevation/copernicus_glo30",
             "minimum_baseline_m": 45,
             "sample_count": 7,
             "max_abs_slope_percent": 40,
         },
+        {
+            "type": "copernicus_glo90",
+            "role": "global_coverage_fallback",
+            "priority": 10,
+            "cache_dir": ".cache/oswm/elevation/copernicus_glo90",
+            "minimum_baseline_m": 135,
+            "sample_count": 7,
+            "max_abs_slope_percent": 40,
+        },
     ],
     "request_timeout_seconds": 120,
+}
+
+HAZARD_TERRAIN_CONFIG = {
+    "enabled": True,
+    "max_dimension": 1600,
+    "smoothing_sigma_pixels": 3.0,
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ matplotlib
 tqdm
 osmapi
 mercantile
+Pillow

--- a/routing/README.md
+++ b/routing/README.md
@@ -73,12 +73,14 @@ option is hidden when distance-only is already selected.
 1. Numeric OSM `incline=*`.
 2. A node-configured high-resolution DTM/COG.
 3. A node-configured regional elevation model.
-4. Copernicus DEM GLO-30.
-5. Unknown slope.
+4. Copernicus DEM GLO-30 Public from the AWS Open Data Registry.
+5. Copernicus DEM GLO-90 from AWS where a public 30 m tile is unavailable.
+6. Unknown slope.
 
 `incline:across=*` is independent and is never inferred from a terrain model.
-Copernicus GLO-30 is a 30 m digital surface model: its result is explicitly
-treated as a low-confidence terrain trend, not a measured sidewalk slope.
+Copernicus GLO-30 and GLO-90 are digital surface models: their results are
+explicitly treated as low-confidence terrain trends, not measured sidewalk
+slopes. Together they provide a globally valid default for OSWM nodes.
 
 Nodes can override the provider list through `ELEVATION_CONFIG` in `config.py`.
 The current template contains an example local COG entry.

--- a/routing/elevation.py
+++ b/routing/elevation.py
@@ -21,7 +21,10 @@ from typing import Any
 from .profile_rules import DEFAULT_ELEVATION_CONFIG, SOURCE_CONFIDENCE
 
 
-COPERNICUS_BASE_URL = "https://copernicus-dem-30m.s3.amazonaws.com"
+COPERNICUS_BASE_URLS = {
+    30: "https://copernicus-dem-30m.s3.amazonaws.com",
+    90: "https://copernicus-dem-90m.s3.amazonaws.com",
+}
 
 
 @dataclass(frozen=True)
@@ -45,22 +48,29 @@ def _finite_float(value: Any) -> float | None:
     return number if math.isfinite(number) else None
 
 
-def copernicus_tile_name(latitude: float, longitude: float) -> str:
-    """Return the Copernicus GLO-30 COG tile identifier for a coordinate."""
+def copernicus_tile_name(
+    latitude: float, longitude: float, resolution_m: int = 30
+) -> str:
+    """Return the AWS Copernicus COG tile identifier for a coordinate."""
 
+    if resolution_m not in COPERNICUS_BASE_URLS:
+        raise ValueError("Copernicus resolution must be 30 or 90 metres")
     south = math.floor(latitude)
     west = math.floor(longitude)
     lat_token = f"N{south:02d}" if south >= 0 else f"S{abs(south):02d}"
     lon_token = f"E{west:03d}" if west >= 0 else f"W{abs(west):03d}"
+    arc_seconds = 10 if resolution_m == 30 else 30
     return (
-        f"Copernicus_DSM_COG_10_{lat_token}_00_"
+        f"Copernicus_DSM_COG_{arc_seconds}_{lat_token}_00_"
         f"{lon_token}_00_DEM"
     )
 
 
-def copernicus_tile_url(latitude: float, longitude: float) -> str:
-    tile = copernicus_tile_name(latitude, longitude)
-    return f"{COPERNICUS_BASE_URL}/{tile}/{tile}.tif"
+def copernicus_tile_url(
+    latitude: float, longitude: float, resolution_m: int = 30
+) -> str:
+    tile = copernicus_tile_name(latitude, longitude, resolution_m)
+    return f"{COPERNICUS_BASE_URLS[resolution_m]}/{tile}/{tile}.tif"
 
 
 def robust_slope_percent(
@@ -212,22 +222,31 @@ class RasterElevationProvider:
         )
 
 
-class CopernicusGLO30Provider(RasterElevationProvider):
-    source_name = "copernicus_glo30"
-    default_confidence = SOURCE_CONFIDENCE["copernicus_glo30"]
-    resolution_m = 30
+class CopernicusDEMProvider(RasterElevationProvider):
+    """Cached AWS Open Data provider for a Copernicus global DEM instance."""
 
     def __init__(self, config: dict[str, Any], request_timeout_seconds: int = 120):
         super().__init__(config, request_timeout_seconds)
+        self.resolution_m = int(config.get("resolution_m", 30))
+        if self.resolution_m not in COPERNICUS_BASE_URLS:
+            raise ValueError("Copernicus resolution must be 30 or 90 metres")
+        self.source_name = f"copernicus_glo{self.resolution_m}"
+        self.default_confidence = SOURCE_CONFIDENCE[self.source_name]
         self.cache_dir = Path(
-            config.get("cache_dir", ".cache/oswm/elevation/copernicus_glo30")
+            config.get(
+                "cache_dir",
+                f".cache/oswm/elevation/{self.source_name}",
+            )
         )
         self._failed_tiles: set[str] = set()
+        self._datasets: dict[Path, Any] = {}
 
     def _local_tile(self, latitude: float, longitude: float) -> Path:
         import requests
 
-        tile = copernicus_tile_name(latitude, longitude)
+        tile = copernicus_tile_name(
+            latitude, longitude, int(self.resolution_m)
+        )
         if tile in self._failed_tiles:
             raise RuntimeError(f"Copernicus tile unavailable during this run: {tile}")
         target = self.cache_dir / f"{tile}.tif"
@@ -238,7 +257,9 @@ class CopernicusGLO30Provider(RasterElevationProvider):
         temporary: Path | None = None
         try:
             with requests.get(
-                copernicus_tile_url(latitude, longitude),
+                copernicus_tile_url(
+                    latitude, longitude, int(self.resolution_m)
+                ),
                 stream=True,
                 timeout=self.request_timeout_seconds,
             ) as response:
@@ -271,14 +292,40 @@ class CopernicusGLO30Provider(RasterElevationProvider):
 
         values = [float("nan")] * len(points_lonlat)
         for path, indexed_points in indexed_by_tile.items():
-            with rasterio.open(path) as dataset:
-                samples = dataset.sample([point for _index, point in indexed_points])
-                nodata = dataset.nodata
-                for (index, _point), sample in zip(indexed_points, samples):
-                    value = float(sample[0])
-                    if nodata is None or value != nodata:
-                        values[index] = value
+            dataset = self._datasets.get(path)
+            if dataset is None or dataset.closed:
+                dataset = rasterio.open(path)
+                self._datasets[path] = dataset
+            samples = dataset.sample([point for _index, point in indexed_points])
+            nodata = dataset.nodata
+            for (index, _point), sample in zip(indexed_points, samples):
+                value = float(sample[0])
+                if nodata is None or value != nodata:
+                    values[index] = value
         return values
+
+    def close(self) -> None:
+        for dataset in self._datasets.values():
+            dataset.close()
+        self._datasets.clear()
+
+
+class CopernicusGLO30Provider(CopernicusDEMProvider):
+    source_name = "copernicus_glo30"
+    default_confidence = SOURCE_CONFIDENCE["copernicus_glo30"]
+    resolution_m = 30
+
+    def __init__(self, config: dict[str, Any], request_timeout_seconds: int = 120):
+        super().__init__({**config, "resolution_m": 30}, request_timeout_seconds)
+
+
+class CopernicusGLO90Provider(CopernicusDEMProvider):
+    source_name = "copernicus_glo90"
+    default_confidence = SOURCE_CONFIDENCE["copernicus_glo90"]
+    resolution_m = 90
+
+    def __init__(self, config: dict[str, Any], request_timeout_seconds: int = 120):
+        super().__init__({**config, "resolution_m": 90}, request_timeout_seconds)
 
 
 class COGElevationProvider(RasterElevationProvider):
@@ -335,6 +382,8 @@ class ElevationResolver:
                 provider_type = provider_config.get("type")
                 if provider_type == "copernicus_glo30":
                     providers.append(CopernicusGLO30Provider(provider_config, timeout))
+                elif provider_type == "copernicus_glo90":
+                    providers.append(CopernicusGLO90Provider(provider_config, timeout))
                 elif provider_type in {"cog", "local_cog"}:
                     providers.append(COGElevationProvider(provider_config, timeout))
                 else:
@@ -382,6 +431,12 @@ class ElevationResolver:
             self.config, sort_keys=True, separators=(",", ":"), default=str
         ).encode("utf-8")
         return hashlib.sha256(payload).hexdigest()[:16]
+
+    def close(self) -> None:
+        for provider in self.providers:
+            close = getattr(provider, "close", None)
+            if callable(close):
+                close()
 
 
 def slope_cache_key(

--- a/routing/grading.py
+++ b/routing/grading.py
@@ -2,190 +2,21 @@
 
 from __future__ import annotations
 
-import math
-import re
 from collections.abc import Mapping, Sequence
 from statistics import fmean
 from typing import Any
 
+from accessibility.normalization import (
+    is_unknown,
+    normalize_categorical,
+    parse_incline_percent,
+    parse_number,
+    parse_width_m,
+    prepare_feature,
+)
+
 from .profile_rules import ROUTING_PROFILES
 from .profile_validation import validate_profiles
-
-
-UNKNOWN_STRINGS = {"", "?", "unknown", "unset", "none", "null", "nan"}
-_NUMBER_RE = re.compile(r"[-+]?(?:\d+(?:[.,]\d*)?|[.,]\d+)")
-
-
-def is_unknown(value: Any) -> bool:
-    if value is None:
-        return True
-    if isinstance(value, str):
-        return value.strip().lower() in UNKNOWN_STRINGS
-    try:
-        return bool(math.isnan(value))
-    except (TypeError, ValueError):
-        # pandas uses dedicated scalar sentinels that deliberately reject
-        # truth-value conversion. Keep this module usable without importing
-        # pandas just to recognize those values.
-        value_type = type(value)
-        return (
-            value_type.__name__ in {"NAType", "NaTType"}
-            and value_type.__module__.startswith("pandas")
-        )
-
-
-def normalize_categorical(value: Any) -> Any:
-    if isinstance(value, str):
-        return value.strip().lower()
-    return value
-
-
-def parse_number(value: Any) -> float | None:
-    """Parse the first finite number from a permissive OSM-style value."""
-
-    if is_unknown(value) or isinstance(value, bool):
-        return None
-    if isinstance(value, (int, float)):
-        number = float(value)
-        return number if math.isfinite(number) else None
-    match = _NUMBER_RE.search(str(value))
-    if not match:
-        return None
-    try:
-        number = float(match.group(0).replace(",", "."))
-    except ValueError:
-        return None
-    return number if math.isfinite(number) else None
-
-
-def parse_width_m(value: Any) -> float | None:
-    """Parse common OSM width forms into metres.
-
-    Semicolon-separated measurements are treated conservatively by retaining
-    the minimum. Feet/inches notation is supported for values such as 4'6".
-    """
-
-    if is_unknown(value):
-        return None
-    text = str(value).strip().lower()
-    if ";" in text:
-        parsed = [parse_width_m(part) for part in text.split(";")]
-        valid = [item for item in parsed if item is not None]
-        return min(valid) if valid else None
-
-    feet_match = re.fullmatch(
-        r"\s*(\d+(?:\.\d+)?)\s*'\s*(?:(\d+(?:\.\d+)?)\s*(?:\"|in)?)?\s*",
-        text,
-    )
-    if feet_match:
-        feet = float(feet_match.group(1))
-        inches = float(feet_match.group(2) or 0)
-        return feet * 0.3048 + inches * 0.0254
-
-    number = parse_number(value)
-    if number is None:
-        return None
-    if "ft" in text or "feet" in text:
-        return number * 0.3048
-    if "cm" in text:
-        return number / 100
-    if "mm" in text:
-        return number / 1000
-    return number
-
-
-def parse_incline_percent(value: Any) -> tuple[float | None, str]:
-    """Return ``(percent, kind)`` for an OSM incline-like value.
-
-    ``kind`` is one of ``numeric``, ``qualitative``, ``missing`` or ``invalid``.
-    Positive values rise in feature-coordinate order.
-    """
-
-    if is_unknown(value):
-        return None, "missing"
-    if isinstance(value, str):
-        text = value.strip().lower()
-        if text in {"up", "uphill"}:
-            return None, "qualitative"
-        if text in {"down", "downhill"}:
-            return None, "qualitative"
-    else:
-        text = str(value)
-
-    number = parse_number(value)
-    if number is None:
-        return None, "invalid"
-    if "°" in text or "deg" in text or "degree" in text:
-        return math.tan(math.radians(number)) * 100, "numeric"
-    # OSM recommends percentages. Bare numeric values are interpreted as
-    # percentages as well, matching established mapper practice.
-    return number, "numeric"
-
-
-def prepare_feature(
-    feature: Mapping[str, Any],
-    *,
-    edge_kind: str | None = None,
-    estimated_slope_percent: float | None = None,
-    slope_source: str = "missing",
-    slope_confidence: int = 0,
-) -> dict[str, Any]:
-    """Normalize a raw edge record into fields consumed by profile rules."""
-
-    prepared = dict(feature)
-    prepared["edge_kind"] = edge_kind or prepared.get("edge_kind") or "footway"
-    prepared["width_m"] = parse_width_m(prepared.get("width"))
-
-    direct_slope, incline_kind = parse_incline_percent(prepared.get("incline"))
-    if direct_slope is not None:
-        prepared["incline_percent"] = direct_slope
-        prepared["incline_source"] = "direct_osm_numeric"
-        prepared["incline_confidence"] = 100
-    else:
-        prepared["incline_percent"] = estimated_slope_percent
-        prepared["incline_source"] = (
-            slope_source if estimated_slope_percent is not None else incline_kind
-        )
-        prepared["incline_confidence"] = (
-            int(slope_confidence) if estimated_slope_percent is not None else 0
-        )
-
-    cross_slope, cross_kind = parse_incline_percent(
-        prepared.get("incline:across")
-    )
-    prepared["cross_slope_percent"] = cross_slope
-    prepared["cross_slope_source"] = (
-        "direct_osm_numeric" if cross_slope is not None else cross_kind
-    )
-    prepared["cross_slope_confidence"] = 100 if cross_slope is not None else 0
-
-    for field in (
-        "surface",
-        "smoothness",
-        "wheelchair",
-        "crossing",
-        "lit",
-        "highway",
-        "access",
-        "foot",
-    ):
-        prepared[field] = normalize_categorical(prepared.get(field))
-
-    for field in ("associated_kerbs", "associated_tactile_paving"):
-        value = prepared.get(field)
-        if is_unknown(value):
-            prepared[field] = []
-        elif isinstance(value, str):
-            prepared[field] = [normalize_categorical(value)]
-        elif isinstance(value, Sequence):
-            prepared[field] = [
-                normalize_categorical(item)
-                for item in value
-                if not is_unknown(item)
-            ]
-        else:
-            prepared[field] = [normalize_categorical(value)]
-    return prepared
 
 
 def _context_applies(rule: Mapping[str, Any], edge_kind: str) -> bool:

--- a/routing/profile_rules.py
+++ b/routing/profile_rules.py
@@ -650,6 +650,7 @@ SOURCE_CONFIDENCE = {
     "local_lidar_dtm": 90,
     "regional_dtm": 75,
     "copernicus_glo30": 45,
+    "copernicus_glo90": 30,
     "osm_qualitative": 35,
     "missing": 0,
 }
@@ -660,10 +661,19 @@ DEFAULT_ELEVATION_CONFIG = {
     "providers": [
         {
             "type": "copernicus_glo30",
-            "role": "global_fallback",
-            "priority": 10,
+            "role": "global_primary",
+            "priority": 20,
             "cache_dir": ".cache/oswm/elevation/copernicus_glo30",
             "minimum_baseline_m": 45,
+            "sample_count": 7,
+            "max_abs_slope_percent": 40,
+        },
+        {
+            "type": "copernicus_glo90",
+            "role": "global_coverage_fallback",
+            "priority": 10,
+            "cache_dir": ".cache/oswm/elevation/copernicus_glo90",
+            "minimum_baseline_m": 135,
             "sample_count": 7,
             "max_abs_slope_percent": 40,
         },

--- a/runners/daily.sh
+++ b/runners/daily.sh
@@ -42,6 +42,21 @@ run_step oswm_codebase/datahub/acquisition/generate_acquisition.py "generate_acq
 if [ -f data/updates/yesterday.json ]; then
     NUM_CHANGESETS=$("$PYTHON_BIN" -c "import json; print(len(json.load(open('data/updates/yesterday.json'))))" 2>/dev/null)
     if [ -n "$NUM_CHANGESETS" ] && [ "$NUM_CHANGESETS" -eq 0 ]; then
+        HAZARD_OUTPUTS_READY=1
+        for PROFILE in pedestrian wheelchair blind elderly; do
+            if [ ! -s "data/hazard_analysis/features_${PROFILE}.geojson" ] || \
+               [ ! -s "data/hazard_analysis/terrain_${PROFILE}.png" ]; then
+                HAZARD_OUTPUTS_READY=0
+            fi
+        done
+        if [ ! -s data/hazard_analysis/profiles.json ] || \
+           [ ! -s data/hazard_analysis/metadata.json ] || \
+           [ ! -s data/hazard_analysis/terrain.json ]; then
+            HAZARD_OUTPUTS_READY=0
+        fi
+        if [ "$HAZARD_OUTPUTS_READY" -eq 0 ]; then
+            echo "Hazard deployment artifacts are missing; continuing generation."
+        else
         echo "========================================="
         echo "No OSM changesets affecting OSWM features yesterday."
         echo "Skipping the remaining OSM-dependent daily updates."
@@ -53,6 +68,7 @@ if [ -f data/updates/yesterday.json ]; then
         fi
         rm -f data/updates/pipeline_failures.txt
         exit 0
+        fi
     fi
 fi
 

--- a/tests/test_hazard_analysis.py
+++ b/tests/test_hazard_analysis.py
@@ -1,0 +1,192 @@
+import unittest
+from pathlib import Path
+
+from accessibility.normalization import prepare_feature
+from hazard_analysis.assessment import assess_feature, compact_hazard_properties
+from hazard_analysis.rules import HAZARD_RULES
+from hazard_analysis.terrain import classify_terrain_slope
+from hazard_analysis.validation import (
+    public_rule_metadata,
+    ruleset_hash,
+    validate_rules,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class HazardRuleValidationTests(unittest.TestCase):
+    def test_live_rules_are_valid_and_complete(self):
+        validate_rules(HAZARD_RULES)
+        self.assertEqual(len(HAZARD_RULES), 29)
+
+    def test_duplicate_rule_id_is_rejected(self):
+        duplicate = [HAZARD_RULES[0], HAZARD_RULES[0]]
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            validate_rules(duplicate)
+
+    def test_ruleset_hash_is_deterministic(self):
+        self.assertEqual(ruleset_hash(HAZARD_RULES), ruleset_hash(HAZARD_RULES))
+
+    def test_public_metadata_does_not_expose_conditions(self):
+        public = public_rule_metadata(HAZARD_RULES)
+        self.assertTrue(public[0]["effects"])
+        self.assertNotIn("condition", public[0])
+
+
+class HazardAssessmentTests(unittest.TestCase):
+    def test_raised_kerb_is_wheelchair_barrier(self):
+        feature = prepare_feature(
+            {"associated_kerbs": ["raised"]}, edge_kind="crossing"
+        )
+        result = assess_feature(feature, normalized=True)
+        wheelchair = result["wheelchair"]["forward"]
+        self.assertEqual(wheelchair["severity"], 4)
+        self.assertEqual(wheelchair["traversability"], "impassable")
+
+    def test_missing_tactile_data_is_unknown_not_dangerous(self):
+        feature = prepare_feature({}, edge_kind="crossing")
+        result = assess_feature(feature, normalized=True)["blind"]["forward"]
+        self.assertEqual(result["severity"], 0)
+        self.assertEqual(result["status"], "insufficient_data")
+
+    def test_explicit_flush_without_tactile_is_critical(self):
+        feature = prepare_feature(
+            {
+                "associated_transition_states": [
+                    {"kerb": "flush", "tactile_paving": "no"}
+                ]
+            },
+            edge_kind="crossing",
+        )
+        result = assess_feature(feature, normalized=True)["blind"]["forward"]
+        self.assertEqual(result["severity"], 4)
+        self.assertEqual(
+            result["traversability"], "passable_with_extreme_risk"
+        )
+
+    def test_crossing_wide_values_do_not_create_false_pair(self):
+        feature = prepare_feature(
+            {
+                "associated_transition_states": [
+                    {"kerb": "flush", "tactile_paving": "yes"},
+                    {"kerb": "raised", "tactile_paving": "no"},
+                ],
+                "associated_tactile_paving": ["yes", "no"],
+            },
+            edge_kind="crossing",
+        )
+        result = assess_feature(feature, normalized=True)["blind"]["forward"]
+        self.assertEqual(result["severity"], 3)
+        self.assertNotIn("flush_without_tactile", result["rule_ids"])
+
+    def test_uniform_surface_requires_all_three_explicit_sources(self):
+        complete = prepare_feature(
+            {
+                "surface": "asphalt",
+                "associated_transition_states": [
+                    {
+                        "kerb_surface": "asphalt",
+                        "sidewalk_surface": "asphalt",
+                    }
+                ],
+            },
+            edge_kind="crossing",
+        )
+        incomplete = prepare_feature(
+            {
+                "surface": "asphalt",
+                "associated_transition_states": [
+                    {"kerb_surface": "asphalt"}
+                ],
+            },
+            edge_kind="crossing",
+        )
+        self.assertTrue(complete["uniform_transition_surface"])
+        self.assertFalse(incomplete["uniform_transition_surface"])
+
+    def test_cross_slope_requires_explicit_data(self):
+        missing = prepare_feature({})
+        explicit = prepare_feature({"incline:across": "6%"})
+        self.assertEqual(
+            assess_feature(missing, normalized=True)["wheelchair"]["forward"][
+                "categories"
+            ]["cross_slope"]["severity"],
+            0,
+        )
+        self.assertEqual(
+            assess_feature(explicit, normalized=True)["wheelchair"]["forward"][
+                "categories"
+            ]["cross_slope"]["severity"],
+            4,
+        )
+
+    def test_longitudinal_slope_is_directional(self):
+        feature = prepare_feature({"incline": "10%"})
+        result = assess_feature(feature, normalized=True)["blind"]
+        self.assertEqual(result["forward"]["severity"], 1)
+        self.assertEqual(result["backward"]["severity"], 2)
+
+    def test_compact_properties_include_categories_and_directions(self):
+        feature = prepare_feature({"surface": "sand"})
+        compact = compact_hazard_properties(
+            assess_feature(feature, normalized=True), "wheelchair"
+        )
+        self.assertIn("forward", compact)
+        self.assertIn("backward", compact)
+        self.assertEqual(compact["category_surface"], 4)
+
+
+class TerrainHazardTests(unittest.TestCase):
+    def test_profile_thresholds_are_classified(self):
+        values = classify_terrain_slope([0, 2.1, 5.1, 8.5, 13], [2, 5, 8.33, 12.5])
+        self.assertEqual(values.tolist(), [0, 1, 2, 3, 4])
+
+
+class HazardClientWiringTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = (
+            ROOT / "hazard_analysis" / "hazard_analysis.html"
+        ).read_text(encoding="utf-8")
+        cls.generator = (
+            ROOT / "generation" / "routing_demo_gen.py"
+        ).read_text(encoding="utf-8")
+        cls.modules = (ROOT / "modules_info.py").read_text(encoding="utf-8")
+        cls.api = (
+            ROOT / "datahub" / "API" / "generate_api.py"
+        ).read_text(encoding="utf-8")
+
+    def test_client_filters_profiles_categories_and_levels(self):
+        for identifier in (
+            'id="profileSelect"',
+            'id="categorySelect"',
+            'id="severitySelect"',
+            'id="confidenceRange"',
+        ):
+            self.assertIn(identifier, self.html)
+        self.assertIn("features_${profile}.geojson", self.html)
+
+    def test_client_explains_missing_data_and_critical_context(self):
+        self.assertIn("not certified safe", self.html)
+        self.assertIn("Apparent mobility barrier", self.html)
+        self.assertIn("Extreme contextual safety risk", self.html)
+
+    def test_client_supports_optional_terrain_raster(self):
+        self.assertIn('id="terrainToggle"', self.html)
+        self.assertIn("terrain-source", self.html)
+        self.assertIn("source_attribution", self.html)
+
+    def test_shared_generator_emits_both_modules(self):
+        self.assertIn("compact_grade_properties", self.generator)
+        self.assertIn("compact_hazard_properties", self.generator)
+        self.assertIn("generate_terrain_overlays", self.generator)
+
+    def test_homepage_and_api_list_hazard_module(self):
+        self.assertIn("hazard_analysis.html", self.modules)
+        self.assertIn("data/hazard_analysis/profiles.json", self.api)
+        self.assertIn('fmt = "PNG"', self.api)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routing_elevation.py
+++ b/tests/test_routing_elevation.py
@@ -2,11 +2,12 @@ import tempfile
 import unittest
 from importlib.util import find_spec
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from routing.elevation import (
     COGElevationProvider,
     CopernicusGLO30Provider,
+    CopernicusGLO90Provider,
     ElevationResolver,
     SlopeEstimate,
     copernicus_tile_name,
@@ -36,6 +37,44 @@ class CopernicusNamingTests(unittest.TestCase):
             copernicus_tile_url(-25.46, -49.26),
             f"https://copernicus-dem-30m.s3.amazonaws.com/{tile}/{tile}.tif",
         )
+
+    def test_global_90m_fallback_naming(self):
+        tile = copernicus_tile_name(-25.46, -49.26, 90)
+        self.assertEqual(
+            tile,
+            "Copernicus_DSM_COG_30_S26_00_W050_00_DEM",
+        )
+        self.assertEqual(
+            copernicus_tile_url(-25.46, -49.26, 90),
+            f"https://copernicus-dem-90m.s3.amazonaws.com/{tile}/{tile}.tif",
+        )
+
+    def test_resolver_builds_both_global_providers(self):
+        resolver = ElevationResolver(
+            {
+                "providers": [
+                    {"type": "copernicus_glo30", "priority": 20},
+                    {"type": "copernicus_glo90", "priority": 10},
+                ]
+            }
+        )
+        self.assertIsInstance(resolver.providers[0], CopernicusGLO30Provider)
+        self.assertIsInstance(resolver.providers[1], CopernicusGLO90Provider)
+
+    def test_global_90m_provider_is_used_when_30m_has_no_result(self):
+        resolver = ElevationResolver({"enabled": False, "providers": []})
+        glo30 = Mock()
+        glo30.estimate.return_value = SlopeEstimate(
+            None, "copernicus_glo30", 0
+        )
+        glo90 = Mock()
+        glo90.estimate.return_value = SlopeEstimate(
+            3.5, "copernicus_glo90", 30, 90, 7
+        )
+        resolver.providers = [glo30, glo90]
+        estimate = resolver.estimate(object())
+        self.assertEqual(estimate.source, "copernicus_glo90")
+        self.assertEqual(estimate.percent, 3.5)
 
     def test_failed_tile_is_not_downloaded_repeatedly(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## What changed

- adds a shared accessibility normalization layer used by routing and hazard analysis
- introduces four pedestrian hazard profiles, five severity levels, six categories, and 29 provisional human-editable rules
- adds directional hazard assessment, explicit missing-data handling, paired kerb/tactile evidence, and surface-transition checks
- adds a static MapLibre Hazard Analysis webmap with profile, category, severity, confidence, insufficient-data, and terrain controls
- adds profile-specific generated GeoJSON outputs, metadata/API integration, homepage artwork, documentation, and deployment safeguards
- makes the default elevation hierarchy globally valid: numeric OSM `incline=*`, AWS Copernicus GLO-30, then AWS Copernicus GLO-90 coverage fallback
- caches open COG datasets during generation to avoid reopening the same raster for every network edge

## Why

OpenSidewalkMap nodes must work globally. The hazard module needs to distinguish conditions affecting general pedestrians, wheelchair users, blind/low-vision pedestrians, and older/reduced-mobility pedestrians without interpreting missing OSM tags as safe values. A city-specific DEM cannot be the default elevation dependency, so the implementation uses the public Copernicus DEM Cloud Optimized GeoTIFFs in the AWS Open Data Registry.

Copernicus is a digital surface model rather than surveyed sidewalk geometry. The UI and metadata therefore describe it as contextual terrain-difficulty potential; terrain never supplies `incline:across=*`, and numeric OSM incline remains authoritative.

## Validation

- `python -m unittest discover -s tests -p 'test_*.py' -v` — 56 tests passed
- Python compile checks passed
- Hazard webmap JavaScript syntax check passed
- shell syntax check passed for the daily runner
- SVG/XML validation passed
- real Curitiba generation produced 17,216 features for each profile
- observed slope provenance: 17,201 GLO-30, 2 GLO-90 fallbacks, and 13 numeric OSM inclines
- generated GeoJSON, PNG, metadata, API, and local HTTP endpoint checks passed

## Follow-up

The dependent reference-node PR should be merged only after this codebase PR so its submodule pointer can target the merged codebase commit.